### PR TITLE
fix(demos): drop Delaunator hull artifacts from Delaunay min-angle stat

### DIFF
--- a/src/components/illustrations/delaunay-voronoi/DelaunayVoronoiCanvas.tsx
+++ b/src/components/illustrations/delaunay-voronoi/DelaunayVoronoiCanvas.tsx
@@ -292,16 +292,16 @@ export default function DelaunayVoronoiCanvas({ demo }: Props) {
                 </g>
             )}
 
-            {/* Layer 4: Delaunay edges */}
-            {layers.delaunay && delaunay && allPoints.length >= 3 && (
+            {/* Layer 4: Delaunay edges — iterate the filtered triangle list so
+                rendered edges, stats, and hover all describe the same triangulation. */}
+            {layers.delaunay && triangles.length > 0 && allPoints.length >= 3 && (
                 <g aria-hidden="true" pointerEvents="none">
                     {(() => {
                         const lines: ReactElement[] = [];
-                        const t = delaunay.triangles;
                         const rendered = new Set<string>();
-                        for (let i = 0; i < t.length; i += 3) {
+                        for (const { ai, bi, ci } of triangles) {
                             const pairs: [number, number][] = [
-                                [t[i], t[i + 1]], [t[i + 1], t[i + 2]], [t[i + 2], t[i]],
+                                [ai, bi], [bi, ci], [ci, ai],
                             ];
                             for (const [u, v] of pairs) {
                                 const key = u < v ? `${u}-${v}` : `${v}-${u}`;

--- a/src/components/illustrations/delaunay-voronoi/DelaunayVoronoiDesktopD.tsx
+++ b/src/components/illustrations/delaunay-voronoi/DelaunayVoronoiDesktopD.tsx
@@ -77,9 +77,7 @@ const TOOLS: { tool: ActiveTool; icon: string; title: string; key: string }[] = 
 ];
 
 function formatMinAngle(deg: number): string {
-    if (deg <= 0) return "—";
-    if (deg < 0.05) return "<0.1°";
-    return `${deg.toFixed(1)}°`;
+    return deg > 0 ? `${deg.toFixed(1)}°` : "—";
 }
 
 export default function DelaunayVoronoiDesktopD({ demo }: Props) {

--- a/src/components/illustrations/delaunay-voronoi/DelaunayVoronoiMobile.tsx
+++ b/src/components/illustrations/delaunay-voronoi/DelaunayVoronoiMobile.tsx
@@ -31,9 +31,7 @@ function minAngleColor(deg: number): string {
 }
 
 function formatMinAngle(deg: number): string {
-    if (deg <= 0) return "—";
-    if (deg < 0.05) return "<0.1°";
-    return `${deg.toFixed(1)}°`;
+    return deg > 0 ? `${deg.toFixed(1)}°` : "—";
 }
 
 export default function DelaunayVoronoiMobile({ demo }: Props) {

--- a/src/components/illustrations/delaunay-voronoi/__tests__/useDelaunayVoronoi.test.ts
+++ b/src/components/illustrations/delaunay-voronoi/__tests__/useDelaunayVoronoi.test.ts
@@ -127,6 +127,25 @@ describe("useDelaunayVoronoi reducer", () => {
         expect(result.current.state.points.length).toBe(0);
     });
 
+    it("default rect grid: stats show all 96 cells with healthy min-angle", () => {
+        const { result } = renderHook(() => useDelaunayVoronoi());
+        act(() => result.current.toggleLayer("grid"));
+        // 6 rows × 8 cols × 2 triangles per cell = 96
+        expect(result.current.stats.triangles).toBe(96);
+        expect(result.current.stats.minAngleDeg).toBeGreaterThan(30);
+    });
+
+    it("small corner move: no Delaunator hull artifacts contaminate min-angle", () => {
+        const { result } = renderHook(() => useDelaunayVoronoi());
+        act(() => result.current.toggleLayer("grid"));
+        // Drag c0 from (80,80) to (130,80) — small convex move that previously surfaced
+        // 3+ phantom collinear "triangles" with ~0 area, polluting min-angle to <0.1°.
+        act(() => result.current.moveCorner(0, 130, 80));
+        act(() => result.current.endDrag());
+        expect(result.current.stats.triangles).toBe(96);
+        expect(result.current.stats.minAngleDeg).toBeGreaterThan(5);
+    });
+
     it("singular grid corners produce no projected grid (no phantom origin cluster)", () => {
         const { result } = renderHook(() => useDelaunayVoronoi());
         act(() => result.current.toggleLayer("grid"));

--- a/src/components/illustrations/delaunay-voronoi/useDelaunayVoronoi.ts
+++ b/src/components/illustrations/delaunay-voronoi/useDelaunayVoronoi.ts
@@ -2,7 +2,7 @@ import { useReducer, useMemo, useCallback } from "react";
 import { Delaunay } from "d3-delaunay";
 import { v4 as uuid } from "uuid";
 import { computeHomography, applyHomography } from "./homography";
-import { triangleMinAngle } from "./geometry";
+import { triangleMinAngle, triangleArea } from "./geometry";
 import type { Point, GridConfig, Layers, ViewState, HoverTarget, ActiveTool, HistorySnapshot } from "./types";
 
 const HISTORY_LIMIT = 50;
@@ -386,11 +386,20 @@ export function useDelaunayVoronoi(): DelaunayVoronoiState {
         if (!delaunay) return [];
         const result: TriangleInfo[] = [];
         const t = delaunay.triangles;
+        // Filter Delaunator hull artifacts: when input has collinear subsets that aren't
+        // axis-aligned (which is every projective grid edge after a corner drag), Delaunator
+        // emits degenerate "triangles" with effectively zero area. They contaminate the
+        // min-angle stat. 1e-3 px² is well below any meaningful triangulation cell and
+        // matches the dedup tolerance used for input points.
+        const TRIANGLE_AREA_EPS = 1e-3;
         for (let i = 0; i < t.length; i += 3) {
-            result.push({ ai: t[i], bi: t[i + 1], ci: t[i + 2] });
+            const ai = t[i], bi = t[i + 1], ci = t[i + 2];
+            const a = allPoints[ai], b = allPoints[bi], c = allPoints[ci];
+            if (triangleArea(a, b, c) <= TRIANGLE_AREA_EPS) continue;
+            result.push({ ai, bi, ci });
         }
         return result;
-    }, [delaunay]);
+    }, [delaunay, allPoints]);
 
     const stats = useMemo((): Stats => {
         if (!delaunay || triangles.length === 0) {
@@ -401,10 +410,7 @@ export function useDelaunayVoronoi(): DelaunayVoronoiState {
         for (const { ai, bi, ci } of triangles) {
             const a = allPoints[ai], b = allPoints[bi], c = allPoints[ci];
             const minRad = triangleMinAngle(a, b, c);
-            // Skip exact zeros (truly degenerate triplets) — those would otherwise drag the
-            // global to 0 even when the rest of the mesh is healthy. Dedupe of coincident
-            // inputs prevents most of these; this guards the residual numerical case.
-            if (Number.isFinite(minRad) && minRad > 0 && minRad < minAngle) minAngle = minRad;
+            if (Number.isFinite(minRad) && minRad < minAngle) minAngle = minRad;
             for (const [u, v] of [[ai, bi], [bi, ci], [ci, ai]] as [number, number][]) {
                 edgeSet.add(u < v ? `${u}-${v}` : `${v}-${u}`);
             }


### PR DESCRIPTION
## Problem

After 1ccc64a shipped, the desktop stats panel still shows \`Min ∠: <0.1°\` whenever the grid layer is on and any corner is moved — even by 10 px to a clearly convex configuration. The previous patch dressed the symptom (\`<0.1°\` display branch) without removing the underlying cause.

## Root cause (verified numerically)

Delaunator emits **degenerate hull artifact triangles** whenever input has collinear subsets that aren't axis-aligned. The projective grid has exactly this property: each row and column maps to a line through two corners (homography preserves lines). For \`c0\` moved 10 px, Delaunator produces 99 triangles where only 96 are real cells; the 3 extras have all three vertices on the same \`c0→c3\` boundary line. \`triangleMinAngle\` returns \`~1e-9\` rad (FP-near-zero) for these, surviving the existing \`>0\` filter and dominating \`Math.min\`.

Reproduction across configurations:

| Corners | Total tris | Real cells | Artifacts | Min angle (after `>0` filter, before fix) | Min angle (after area filter, this PR) |
|---|---|---|---|---|---|
| Default rect | 96 | 96 | 0 | 42.51° | 42.51° |
| c0 + 10 px | 99 | 96 | 3 | **0.00°** | 42.58° |
| c0 → (200,200) | 102 | 96 | 6 | **0.00°** | 34.89° |
| c0 → (400,280) | 117 | 96 | 21 | **0.00°** | 2.62° |

## Fix

Filter triangles by area (\`≤ 1e-3 px²\`) at the \`triangles\` memo in \`useDelaunayVoronoi.ts\`. The rest of the pipeline (stats, hover, edge rendering) consumes the cleaned list. The \`<0.1°\` display branch is removed since the underlying number is now honest.

## Test plan

- [x] \`bun run lint\`
- [x] \`bun run build\`
- [x] \`npx vitest run\` — 199 pass (2 new)
- [ ] manual: open the demo, toggle grid, drag corners; min-angle stat now reads a real number that decreases smoothly with distortion, never \`<0.1°\` for normal configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)