### PR TITLE
fix(targetgen): raise PuzzleBoard rows/cols cap to 501

### DIFF
--- a/src/components/targetgen/panels/PuzzleboardGenConfig.tsx
+++ b/src/components/targetgen/panels/PuzzleboardGenConfig.tsx
@@ -19,9 +19,9 @@ export default function PuzzleboardGenConfig({ config, dispatch }: Props) {
                     onChange={(v) => update({ rows: v ?? 7 })}
                     disabled={false}
                     min={1}
-                    max={50}
+                    max={501}
                     step={1}
-                    tooltip="Number of square rows on the board"
+                    tooltip="Number of square rows on the board (max 501 — the master pattern's period)"
                 />
                 <NumberField
                     label="Cols"
@@ -29,9 +29,9 @@ export default function PuzzleboardGenConfig({ config, dispatch }: Props) {
                     onChange={(v) => update({ cols: v ?? 10 })}
                     disabled={false}
                     min={1}
-                    max={50}
+                    max={501}
                     step={1}
-                    tooltip="Number of square columns on the board"
+                    tooltip="Number of square columns on the board (max 501 — the master pattern's period)"
                 />
                 <NumberField
                     label="Cell size (mm)"

--- a/src/components/targetgen/svg/puzzleboardSvg.test.ts
+++ b/src/components/targetgen/svg/puzzleboardSvg.test.ts
@@ -75,4 +75,24 @@ describe("puzzleboardSvg", () => {
             expect(c).toContain(rAttr);
         }
     });
+
+    it("renders large boards (200x200) with the expected primitive counts", () => {
+        const big: PuzzleboardConfig = { rows: 200, cols: 200, cellSizeMm: 1 };
+        const bigPage: PageDimensions = { widthMm: 250, heightMm: 250, marginMm: 5 };
+        const svg = puzzleboardSvg(big, bigPage);
+        expect(svg).toMatch(/^<svg/);
+        const rects = svg.match(/<rect/g)!;
+        const circles = svg.match(/<circle/g)!;
+        expect(rects.length).toBe(200 * 200 + 1);
+        expect(circles.length).toBe(199 * 200 + 200 * 199);
+    });
+
+    it("renders boards at the master-period maximum (501x501) without error", () => {
+        const max: PuzzleboardConfig = { rows: 501, cols: 501, cellSizeMm: 0.5 };
+        const maxPage: PageDimensions = { widthMm: 300, heightMm: 300, marginMm: 5 };
+        const svg = puzzleboardSvg(max, maxPage);
+        expect(svg).toMatch(/^<svg/);
+        const rects = svg.match(/<rect/g)!;
+        expect(rects.length).toBe(501 * 501 + 1);
+    });
 });


### PR DESCRIPTION
## Summary
- The PuzzleBoard form input capped rows/cols at 50, but the pattern is designed for grids up to 501×501 — the `lcm(3, 167)` period of the de Bruijn factor maps. Beyond 501, 3×3 windows repeat and detection breaks; below 501, every window is unique and the design works as intended.
- Lift the UI input `max` from 50 to 501 for both rows and cols. Tooltip updated to explain the new ceiling. No other code path needed changes — the bit lookups are cyclic over 501, and validation already errors when the board doesn't fit the page.
- Add stress tests at 200×200 and 501×501 to lock in correctness at scale.

## Test plan
- [x] `npx vitest run` — 238/238 (10 in `puzzleboardSvg.test.ts` including the two new large-grid cases)
- [x] `bun run lint`
- [x] `bun run build`
- [ ] Manual: open the target generator, set rows=400, cols=400, cellSizeMm=0.5, page A0; confirm the SVG renders and downloads as a true vector file (page-fit validation will trigger sensibly when the board doesn't fit the chosen paper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)