### PR TITLE
fix(ringgrid): migrate to v5 board and config schema (bump 0.6.0 → 0.10.1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@vitavision/calib-targets": "^0.8.0",
         "@vitavision/chess-corners": "^0.11.2",
         "@vitavision/radsym": "^0.4.1",
-        "@vitavision/ringgrid": "^0.6.0",
+        "@vitavision/ringgrid": "^0.10.1",
         "d3-delaunay": "^6.0.4",
         "framer-motion": "^12.42.2",
         "jszip": "^3.10.1",
@@ -484,7 +484,7 @@
 
     "@vitavision/radsym": ["@vitavision/radsym@0.4.1", "", {}, "sha512-Fy8+ECUZlWOeBcoTYmhcjfDy+cGRqM2SrjkLLSIQlUO/272nyYgdhBifRkn04Tfbn4HjwR/GxlqUMOWkQaS9+w=="],
 
-    "@vitavision/ringgrid": ["@vitavision/ringgrid@0.6.0", "", {}, "sha512-9n5rp/onwelmxC+t1Sqkh3b+TMIFA8uQzqQQPvQbTN03YP9anZUfBliK4RnHfDSRY88vHpxsBprdfR+TRhF2FQ=="],
+    "@vitavision/ringgrid": ["@vitavision/ringgrid@0.10.1", "", {}, "sha512-Cy2cfC0vYLbDY6ab9ALFQ1twrzKaJj8W61uW1dOPpsz38p0RAb4wbQzJlPTaFq4I+Oa1hy/SWUDXeafn6lwQTg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vitavision/calib-targets": "^0.8.0",
     "@vitavision/chess-corners": "^0.11.2",
     "@vitavision/radsym": "^0.4.1",
-    "@vitavision/ringgrid": "^0.6.0",
+    "@vitavision/ringgrid": "^0.10.1",
     "d3-delaunay": "^6.0.4",
     "framer-motion": "^12.42.2",
     "jszip": "^3.10.1",

--- a/scripts/test-wasm-schemas.ts
+++ b/scripts/test-wasm-schemas.ts
@@ -51,15 +51,82 @@ process.exit(0);
         code: `
 const mod = await import('@vitavision/ringgrid');
 await mod.default();
+
+// 1. Schema check: v5, not the legacy flat v4.
 const def = JSON.parse(mod.default_board_json());
-if (def.schema !== 'ringgrid.target.v4' || typeof def.name !== 'string')
-    throw new Error('default board missing schema/name');
-console.log('PASS: default board JSON has schema + name');
-const user = { rows: 15, long_row_cols: 14, pitch_mm: 8.0, marker_outer_radius_mm: 5.6, marker_inner_radius_mm: 3.2, marker_ring_width_mm: 0.8 };
-const merged = { ...def, ...user };
-const det = new mod.RinggridDetector(JSON.stringify(merged));
+if (def.schema !== 'ringgrid.target.v5' || typeof def.name !== 'string')
+    throw new Error('default board missing schema/name: ' + JSON.stringify(def));
+console.log('PASS: default board JSON has schema ringgrid.target.v5 + name');
+
+// 2. Build a board through the same nested-aware merge path the adapter/worker
+// use (wasmWorker.ts handleRinggrid), with non-default values, and assert the
+// nested structure is correct AND that untouched sibling keys (lattice.kind,
+// coding.kind) survive — a shallow {...target, ...source} merge would wipe them.
+function deepMerge(target, source) {
+    const out = { ...target };
+    for (const key of Object.keys(source)) {
+        const sv = source[key], tv = target[key];
+        if (sv !== null && typeof sv === 'object' && !Array.isArray(sv) && tv !== null && typeof tv === 'object' && !Array.isArray(tv))
+            out[key] = deepMerge(tv, sv);
+        else out[key] = sv;
+    }
+    return out;
+}
+const adapterBoardOverride = {
+    lattice: { rows: 9, long_row_cols: 8, pitch_mm: 12 },
+    marker: { outer_radius_mm: 5.6, inner_radius_mm: 3.2 },
+    coding: { ring_width_mm: 1.0 },
+};
+const merged = deepMerge(def, adapterBoardOverride);
+if (merged.lattice.kind !== 'hex')
+    throw new Error('lattice.kind was dropped by merge: ' + JSON.stringify(merged.lattice));
+if (merged.lattice.rows !== 9 || merged.lattice.long_row_cols !== 8 || merged.lattice.pitch_mm !== 12)
+    throw new Error('lattice override not applied: ' + JSON.stringify(merged.lattice));
+if (merged.coding.kind !== 'coded16' || merged.coding.ring_width_mm !== 1.0)
+    throw new Error('coding merge incorrect: ' + JSON.stringify(merged.coding));
+if (merged.marker.outer_radius_mm !== 5.6 || merged.marker.inner_radius_mm !== 3.2)
+    throw new Error('marker override not applied: ' + JSON.stringify(merged.marker));
+console.log('PASS: nested board merge applies overrides while preserving lattice.kind/coding.kind');
+const det0 = new mod.RinggridDetector(JSON.stringify(merged));
+det0.free();
+console.log('PASS: detector constructs from merged non-default v5 board');
+
+// 3. Round-trip: update_config with an overlay carrying non-default values
+// under the new advanced.* nesting, then read back config_json() and assert
+// those exact values are present AND that untouched sibling fields survive
+// (catches a knob being silently dropped by the advanced-block move).
+const det = new mod.RinggridDetector(mod.default_board_json());
+const overlay = {
+    marker_scale: { diameter_min_px: 22 },
+    advanced: { decode: { min_decode_confidence: 0.55 } },
+};
+det.update_config(JSON.stringify(overlay));
+const effective = JSON.parse(det.config_json());
+if (effective.marker_scale.diameter_min_px !== 22)
+    throw new Error('marker_scale.diameter_min_px overlay was dropped: ' + JSON.stringify(effective.marker_scale));
+if (effective.advanced.decode.min_decode_confidence !== 0.55)
+    throw new Error('advanced.decode.min_decode_confidence overlay was dropped: ' + JSON.stringify(effective.advanced.decode));
+if (effective.marker_scale.diameter_max_px !== 66)
+    throw new Error('unrelated sibling field diameter_max_px was clobbered: ' + effective.marker_scale.diameter_max_px);
+if (effective.advanced.decode.max_decode_dist !== 3)
+    throw new Error('unrelated sibling field max_decode_dist was clobbered: ' + effective.advanced.decode.max_decode_dist);
+console.log('PASS: update_config round-trip preserves overlay values under advanced.* and leaves siblings untouched');
 det.free();
-console.log('PASS: detector created from merged user + default board JSON');
+
+// 4. Real-image detection: run detect_adaptive_rgba on public/ringgrid.png and
+// assert markers are actually detected, not merely that the call returns.
+const { PNG } = await import('pngjs');
+const { readFileSync } = await import('fs');
+const png = PNG.sync.read(readFileSync('public/ringgrid.png'));
+const detImg = new mod.RinggridDetector(mod.default_board_json());
+const resultJson = detImg.detect_adaptive_rgba(new Uint8Array(png.data), png.width, png.height);
+const result = JSON.parse(resultJson);
+const markers = result.detected_markers ?? [];
+if (markers.length === 0)
+    throw new Error('no markers detected on public/ringgrid.png');
+console.log('PASS: detected ' + markers.length + ' markers on real ringgrid.png image');
+detImg.free();
+
 process.exit(0);
 `,
     },

--- a/src/components/editor/algorithms/ringgrid/RinggridConfigForm.tsx
+++ b/src/components/editor/algorithms/ringgrid/RinggridConfigForm.tsx
@@ -16,7 +16,6 @@ export interface RinggridConfig {
     diameterMaxPx: number;
     // Proposal
     gradThreshold: number;
-    edgeThinning: boolean;
     // Decode
     maxDecodeDist: number;
     minDecodeConfidence: number;
@@ -141,13 +140,6 @@ const RinggridConfigForm = (props: AlgorithmConfigFormProps<RinggridConfig>) => 
                     min={0}
                     max={1}
                     step={0.01}
-                />
-                <CheckboxField
-                    label="Edge thinning"
-                    tooltip="Apply non-maximum suppression to gradient field before voting."
-                    checked={config.edgeThinning}
-                    onChange={(v) => set("edgeThinning", v)}
-                    disabled={disabled}
                 />
             </CollapsibleSection>
             <CollapsibleSection title="Decode" columns={modal ? 2 : undefined}>

--- a/src/components/editor/algorithms/ringgrid/adapter.ts
+++ b/src/components/editor/algorithms/ringgrid/adapter.ts
@@ -18,7 +18,6 @@ const initialConfig: RinggridConfig = {
     diameterMinPx: 14,
     diameterMaxPx: 66,
     gradThreshold: 0.05,
-    edgeThinning: true,
     maxDecodeDist: 3,
     minDecodeConfidence: 0.3,
     enableCompletion: true,
@@ -89,30 +88,43 @@ export const ringgridAlgorithm: AlgorithmDefinition = {
     },
     runWasm: async ({ pixels, width, height, config }) => {
         const c = config as RinggridConfig;
+        // ringgrid.target.v5 nests layout fields under lattice/marker/coding.
+        // This is a partial override merged (nested-aware) onto the WASM
+        // module's default board in wasmWorker.ts — do not add `kind` here,
+        // it must come from the module defaults.
         const boardJson = JSON.stringify({
-            rows: c.rows,
-            long_row_cols: c.longRowCols,
-            pitch_mm: c.pitchMm,
-            marker_outer_radius_mm: c.markerOuterRadiusMm,
-            marker_inner_radius_mm: c.markerInnerRadiusMm,
-            marker_ring_width_mm: c.markerRingWidthMm,
+            lattice: {
+                rows: c.rows,
+                long_row_cols: c.longRowCols,
+                pitch_mm: c.pitchMm,
+            },
+            marker: {
+                outer_radius_mm: c.markerOuterRadiusMm,
+                inner_radius_mm: c.markerInnerRadiusMm,
+            },
+            coding: {
+                ring_width_mm: c.markerRingWidthMm,
+            },
         });
+        // Detection config: proposal/decode/completion moved under `advanced`
+        // in the v5 config schema; marker_scale and self_undistort stay top-level.
         const configOverlay = JSON.stringify({
             marker_scale: {
                 diameter_min_px: c.diameterMinPx,
                 diameter_max_px: c.diameterMaxPx,
             },
-            proposal: {
-                grad_threshold: c.gradThreshold,
-                edge_thinning: c.edgeThinning,
-            },
-            decode: {
-                codebook_profile: c.profile === "extended" ? "extended" : "base",
-                max_decode_dist: c.maxDecodeDist,
-                min_decode_confidence: c.minDecodeConfidence,
-            },
-            completion: { enable: c.enableCompletion },
             self_undistort: { enable: c.enableSelfUndistort },
+            advanced: {
+                proposal: {
+                    grad_threshold: c.gradThreshold,
+                },
+                decode: {
+                    codebook_profile: c.profile === "extended" ? "extended" : "base",
+                    max_decode_dist: c.maxDecodeDist,
+                    min_decode_confidence: c.minDecodeConfidence,
+                },
+                completion: { enable: c.enableCompletion },
+            },
         });
         return detectRinggridWasm(pixels, width, height, { boardJson, configOverlay });
     },

--- a/src/lib/wasm/wasmWorker.ts
+++ b/src/lib/wasm/wasmWorker.ts
@@ -502,12 +502,16 @@ async function handleRinggrid(
 ) {
     const mod = await getRinggridModule();
 
-    // Start from WASM defaults, override with user-provided fields
+    // Start from WASM defaults, override with user-provided fields.
+    // ringgrid.target.v5 nests layout under lattice/marker/coding, so a
+    // shallow merge would wipe sibling keys (e.g. lattice.kind) whenever the
+    // user overrides only part of a nested block — use the nested-aware
+    // deepMerge (defined below in this file) instead.
     const defaults = JSON.parse(mod.default_board_json()) as Record<string, unknown>;
     const userBoard = config.boardJson
         ? JSON.parse(config.boardJson as string) as Record<string, unknown>
         : {};
-    const merged = { ...defaults, ...userBoard };
+    const merged = deepMerge(defaults, userBoard);
     const boardJson = JSON.stringify(merged);
 
     const detector = new mod.RinggridDetector(boardJson);


### PR DESCRIPTION
Unblocks #98, which I held back from the consolidated dependency refresh in #102 because the bump is breaking.

Both breakages fail **silently**. `update_config` accepts an old-shape overlay without error and just drops the values — no throw, no type error, no test failure. Demonstrated directly against the real module:

```
old flat overlay {decode:{min_decode_confidence:0.55}}
  -> effective advanced.decode.min_decode_confidence = 0.3   (default: silently dropped)
new nested overlay {advanced:{decode:{min_decode_confidence:0.55}}}
  -> effective advanced.decode.min_decode_confidence = 0.55  (applied)
```

## What changed upstream

**Board JSON — `ringgrid.target.v4` (flat) → `v5` (nested)**

| v4 | v5 |
|---|---|
| `rows`, `long_row_cols`, `pitch_mm` | `lattice.*` |
| `marker_outer_radius_mm`, `marker_inner_radius_mm` | `marker.outer_radius_mm`, `marker.inner_radius_mm` |
| `marker_ring_width_mm` | `coding.ring_width_mm` |

The adapter emits a **partial** override only — `lattice.kind` and `coding.kind` come from the module defaults rather than being hardcoded.

**Config overlay** — `proposal`, `decode`, `completion` moved under `advanced`; `marker_scale` and `self_undistort` stay top-level.

Without this, every board-geometry control in the editor silently reverts to the default 15×14 hex board at 8 mm pitch.

## Two further findings while migrating

- **`handleRinggrid` had a latent bug.** It merged the user board onto defaults with `{...a, ...b}`. Under v5 that's not a style issue — a partial `lattice` override wipes `lattice.kind` and the detector throws `missing field 'kind'` at construction. Switched to the existing `deepMerge` helper.
- **`edge_thinning` no longer exists** anywhere in the config tree (searched the whole default config for `/thin/i` — zero matches). Removed end to end: config field, `initialConfig` default, and the form toggle. A dead UI control that silently does nothing is worse than dropping it.

## The test is the point

The old ringgrid case merged flat keys and asserted only that the detector constructs — which still *passes* under v5. That is precisely why this was invisible. Replaced with four assertions that have teeth:

1. schema is `v5`
2. a non-default nested board preserves `lattice.kind` / `coding.kind`
3. **round-trip** — `update_config` with non-default values, read back `config_json()`, assert they landed *and* that untouched siblings didn't move
4. **real-image detection** on `public/ringgrid.png` → **62 markers**

## Verification

`bun run scripts/test-wasm-schemas.ts` → **17 passed, 0 failed** (was 14) · `bun run lint` · 277/277 tests · `bun run build`

Once merged, #98 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwFzcPMcsqkG1PCLcgg2as