### PR TITLE
docs: align authoring skills and templates with the relations[] schema

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,7 +71,7 @@ For symmetric relation types (`compared_with`, `alternative_formulation_of`, `pa
 - **Concept page**: when the topic is a genuinely fundamental, cross-cutting CV concept that can support ≥500 words of substantive standalone content (definition, math, numerical concerns, implementation implications). The number of pages referencing the concept is **not** a gate — fundamental concepts get a page even before their dependents are written. Source-diversity still applies: a concept must synthesise ≥3 distinct sources (see the `concept-page` skill).
 - **Failure-mode page**: only when referenced by 3+ algorithm/model pages AND can support ≥500 words. Failure-mode authoring is deferred until natural candidates accumulate.
 - **Pairwise comparison page**: prohibited. Use `relations[type=compared_with]` + an inline `## When to choose X over Y` section inside the more authoritative page. The non-host page carries a single Remarks bullet linking to the comparison anchor — never duplicate the prose. When the relationship is supersession, alternative formulation, parallel foundation, extension, pipeline, or cross-paradigm rather than peer practitioner-choice, pick the appropriate `type` from the Relations field vocabulary below.
-- **Survey concept page** (3+ methods): a concept page (`content/concepts/<survey-slug>.md`), not an algorithm page. Required: ≥3 surveyed methods, ≥800 words, decision table near the top, every surveyed algorithm page lists the survey concept in its `related`. Author only when ≥3 of the surveyed papers have research notes.
+- **Survey concept page** (3+ methods): a concept page (`content/concepts/<survey-slug>.md`), not an algorithm page. Required: ≥3 surveyed methods, ≥800 words, decision table near the top, every surveyed algorithm page lists the survey concept in its `prerequisites`. Author only when ≥3 of the surveyed papers have research notes.
 
 ### Comparison authoring discipline
 - **More-authoritative tiebreaker** for which page hosts the `## When to choose X over Y` section: (1) older paper hosts; (2) same year → more general scope hosts; (3) tied → author judgment with reason recorded in the commit message. No "more cited" rule. The tiebreaker applies only to **peer** comparisons; it does not apply when one method supersedes the other (see Rule A).
@@ -133,7 +133,15 @@ Each registered source has a corresponding research note at `docs/research/notes
 Concept pages may omit `sources:` if no canonical source exists.
 
 ### Validation
-Run `bun run scripts/validate-content.ts` before opening a PR. The build runs the same validation and will fail on broken slugs, prerequisite cycles, missing source IDs, or canonical-quality violations.
+Run `bun run scripts/validate-content.ts` **by path** before opening a PR. It checks slug
+resolution (including `relations[].target`), prerequisite cycles, source-id existence, and
+canonical-quality gates.
+
+Nothing automated runs it. `bun run build` does not, and CI's `validate-content` job runs
+`bun run content:validate` → `scripts/content-validate.ts`, a different and much narrower
+script that only checks blog/algorithm internal links and `relatedPosts`. So a broken
+`relations[].target` slug or a prerequisite cycle will pass CI. Until that gap is closed,
+the manual run is the only gate — do not skip it.
 
 ### Research notes (unpublished reasoning substrate)
 

--- a/.claude/skills/algo-page/SKILL.md
+++ b/.claude/skills/algo-page/SKILL.md
@@ -149,7 +149,6 @@ author: "..."
 difficulty: ...               # beginner | intermediate | advanced
 draft: false
 relatedPosts: [...]           # Blog post slugs
-relatedAlgorithms: [...]      # Other algorithm page slugs
 relatedDemos: [...]           # Demo page slugs
 editorAlgorithmId: ...        # chess-corners | chessboard | charuco | markerboard | ringgrid | radsym
 sources:                      # Authoritative sources for this page (see Workflow section)
@@ -211,12 +210,12 @@ The note's `## NEW: <slug>` or `## UPDATE: <slug>` block provides authoritative 
 **Explicit rules:**
 
 - **1:1 page = primary paper.** Every algorithm page has exactly one primary paper in `sources.primary`. Supplementary papers go in `sources.references` only.
-- **No pairwise comparison pages.** Use `comparedWith:` field + an inline `## When to choose X over Y` section inside the more authoritative page. Surveys allowed only with ≥3 methods, ≥800 words, and a decision table.
+- **No pairwise comparison pages.** Use `relations[type=compared_with]` + an inline `## When to choose X over Y` section inside the more authoritative page. Surveys allowed only with ≥3 methods, ≥800 words, and a decision table.
 - **Never publish raw LLM summaries.** Always synthesize against the research note's structured fields and your own understanding. Each claim must trace to a paper section, equation, or impl line.
 - **Cite source IDs only from `docs/papers/index.yaml`.** Do not invent paper IDs.
-- **Never reference unresolved slugs.** Verify every slug in `relatedAlgorithms`, `prerequisites`, `comparedWith` exists on disk before adding it.
+- **Never reference unresolved slugs.** Verify every slug in `relations[].target` and `prerequisites` exists on disk before adding it.
 - **Do not author reverse edges.** `usedBy:` and similar reverse fields are computed by the build. Never add them manually.
-- Use `quality: stub` only for intentional public placeholders; `quality: canonical` only when the canonical gate is satisfied (sources present, prerequisites non-empty, no TODO markers); `quality: historical` only when a same-domain successor on the site supersedes this method (per CLAUDE.md → Comparison authoring discipline → Rule A). Historical pages must include at least one `relations[]` entry with `{ type: generalized_by, confidence: high, target: <successor-slug> }`, drop `editorAlgorithmId`, and omit `comparedWith:` entirely.
+- Use `quality: stub` only for intentional public placeholders; `quality: canonical` only when the canonical gate is satisfied (sources present, prerequisites non-empty, no TODO markers); `quality: historical` only when a same-domain successor on the site supersedes this method (per CLAUDE.md → Comparison authoring discipline → Rule A). Historical pages must include at least one `relations[]` entry with `{ type: generalized_by, confidence: high, target: <successor-slug> }`, drop `editorAlgorithmId`, and omit any `relations[type=compared_with]` entry entirely.
 
 ## Workflow
 
@@ -240,7 +239,7 @@ B2. **Fetch metadata.** `bun papers:fetch-meta <arg>`; capture stdout YAML. Revi
 B3. **Append to `docs/papers/index.yaml`.** Use the `Edit` tool to insert the stanza at the end of the file. Preserve the inline `# <title>` comments on unresolved `<name><year>-???` cite lines — they are the only hint about what each placeholder refers to. Show the user the diff after the write.
 
 B4. **Curate the cites list.** Each `<name><year>-???` entry is a paper the primary cites but the registry doesn't have yet. Decide per line:
-  - **Chase** if the placeholder is a direct algorithmic antecedent worth showing in the page's `# References` or as a `relatedAlgorithms` cross-link (the corner detector fed into this algorithm, the numerical method it builds on, the paper that introduced the same idea in a different context). Recurse on steps B2–B3 to fetch and append each one.
+  - **Chase** if the placeholder is a direct algorithmic antecedent worth showing in the page's `# References` or as a `relations[]` cross-link (the corner detector fed into this algorithm, the numerical method it builds on, the paper that introduced the same idea in a different context). Recurse on steps B2–B3 to fetch and append each one.
   - **Drop** if the placeholder is tangential (cited in passing, a generic textbook, the venue's comparison survey, a self-citation from the authors). Delete the line from the primary's `cites:` block.
   - Report the keep/drop decisions in the turn log. When in doubt between chase and drop, read the primary (after step B5) for context first.
 
@@ -255,10 +254,10 @@ B8. **Synthesize the frontmatter.** No body yet — just the yaml block.
   - `sources.primary`: the paper id.
   - `sources.references`: curated — direct antecedents from B4 plus any cross-link candidates from `bun papers:query pages-using <ref-id>`. These are the papers that will appear in `# References`.
   - `sources.notes`: freeform summary of key equations, symbols, and constants grounding the page.
-  - `relatedAlgorithms`: union of `bun papers:query pages-using <ref-id>` over `sources.references`, plus judgment-based cross-links from the same algorithmic family.
+  - Citation-graph candidates from `bun papers:query pages-using <ref-id>` over `sources.references`, plus judgment-based cross-links from the same algorithmic family, are candidates for `relations[]` entries — pick the correct `type` and `confidence` per CLAUDE.md → "Relations field", or omit the edge (Rule B) if the methods are not comparable.
   - **Omit `sources.impl` and `editorAlgorithmId`.** Neither can be inferred safely. Add them only when the user supplies a repo URL or names an existing adapter id.
   - **Typed relations.** If the research note's `## NEW: <slug>` or `## UPDATE: <slug>` block records a `Relations:` block (one or more `{ type, target, confidence, caution }` entries — recorded by `paper-ingest` Step 4b), copy each entry into the frontmatter `relations:` list verbatim. Verify each `target` slug resolves to an on-disk page before writing.
-  - **Historical fork.** If the research note ALSO records `Quality: historical`, set `quality: historical` in the frontmatter; **drop** `editorAlgorithmId` (no Try-in-editor CTA on a historical page); **omit** `comparedWith` entirely (per CLAUDE.md → Comparison authoring discipline → Rule A — supersession is not comparison). The historical fork requires that at least one of the copied `relations[]` entries is `{ type: generalized_by, confidence: high }` and that its target is non-draft, non-historical — the validator (Rule 4b) enforces this.
+  - **Historical fork.** If the research note ALSO records `Quality: historical`, set `quality: historical` in the frontmatter; **drop** `editorAlgorithmId` (no Try-in-editor CTA on a historical page); **omit** any `relations[type=compared_with]` entry entirely (per CLAUDE.md → Comparison authoring discipline → Rule A — supersession is not comparison). The historical fork requires that at least one of the copied `relations[]` entries is `{ type: generalized_by, confidence: high }` and that its target is non-draft, non-historical — the validator (Rule 4b) enforces this.
 
 B9. **Write `content/algorithms/<slug>.md`** with the frontmatter above — no body. Then continue with Workflow §4.
 
@@ -278,7 +277,7 @@ B9. **Write `content/algorithms/<slug>.md`** with the frontmatter above — no b
 1. **Read `sources` from the page frontmatter.** If absent, run Bootstrap above.
 2. **Confirm research notes.** Verify `docs/research/notes/<primary-id>.md` exists. For each `<ref-id>` in `sources.references`, verify `docs/research/notes/<ref-id>.md` exists. Any missing note → stop, tell the user to run `/paper-ingest` first. Do NOT fall back to reading the cache.
 3. **Cache the impl** (only if `sources.impl` is set). `bun impls:fetch <slug>` writes raw files into `docs/impls/.cache/<owner>/<repo>/<sha>/<file>`. Opus will pass these paths to the Draft subagent in Step 7.
-4. **Query the citation graph** (lightweight, in-orchestrator). `bun papers:query cites <primary-id>` and `bun papers:query pages-using <ref-id>` for each reference — used to populate `relatedAlgorithms` candidates. Output is small (slug list).
+4. **Query the citation graph** (lightweight, in-orchestrator). `bun papers:query cites <primary-id>` and `bun papers:query pages-using <ref-id>` for each reference — used to populate `relations[]` cross-link candidates. Output is small (slug list).
 5. **Read frontmatter of candidate cross-link pages.** For each candidate slug from §4, read only the page's frontmatter (cheap, ~200 tokens each). Do not load page bodies. Use the frontmatter `summary` and `sources.primary` to confirm a cross-link makes sense.
 6. **Assemble the Draft contract input.** Collect: primary note path, reference note paths, cached impl file paths, page-template skeleton path, target slug. **Pick the template on `frontmatter.quality`**: when `quality: "historical"`, pass `references/algo-page-template-historical.md` (trimmed: Goal + Historical context + References — no Algorithm/Implementation/Remarks); otherwise pass `references/algo-page-template.md`. **Opus does NOT read the notes themselves at this step** — the Draft subagent will.
 7. **Delegate the page draft to Sonnet.** Invoke the Draft contract from `.claude/skills/_shared/subagent-prompts.md` with the inputs from §6. Sonnet returns:
@@ -299,7 +298,7 @@ B9. **Write `content/algorithms/<slug>.md`** with the frontmatter above — no b
    # Zero MISS lines = page faithfully copies from notes
    ```
    Any MISS line means either (a) the note is incomplete and should be extended, or (b) Sonnet hallucinated. In case (a), extend the note and re-delegate. In case (b), reject the draft and re-delegate with a stricter prompt.
-9. **Assemble and write.** Opus assembles `--- frontmatter ---\n<body string from Sonnet>` and calls `Write` once. The frontmatter `prerequisites` / `relatedAlgorithms` / `comparedWith` slugs come from the note's `Connections` section + the §4 citation-graph candidates, NOT from the body string. Cross-check every slug against `knownSlugs` (read from `src/generated/content-graph.ts` or by listing `content/{algorithms,models,concepts}/`).
+9. **Assemble and write.** Opus assembles `--- frontmatter ---\n<body string from Sonnet>` and calls `Write` once. The frontmatter `prerequisites` / `relations[].target` slugs come from the note's `Connections` section + the §4 citation-graph candidates, NOT from the body string. Cross-check every slug against `knownSlugs` (read from `src/generated/content-graph.ts` or by listing `content/{algorithms,models,concepts}/`).
 10. **Verify.** `bun run build && bun run lint && npx vitest run`.
 
 ## Voice rules
@@ -360,7 +359,7 @@ Run before handing off a draft.
 - [ ] If `editorAlgorithmId` is set, the sample-id mapping in `src/pages/AlgorithmPost.tsx` covers it and the "Try in the editor" button lands the user in editor mode with an image preloaded and the algorithm preselected — one click to Run.
 - [ ] A research note exists for `sources.primary` AND every entry in `sources.references`. Page draft is the result of the Draft contract on those notes; the orchestrator did not load any `docs/papers/.cache/*` file.
 - [ ] AUDIT JSON returned by the Draft subagent has zero MISS entries when grep-checked against the cited notes (verification recipe in `_shared/subagent-prompts.md`).
-- [ ] Frontmatter `prerequisites` / `relatedAlgorithms` / `comparedWith` slugs were sourced from the primary note's `Connections` section + §4 citation-graph candidates, NOT taken from the body string Sonnet returned.
+- [ ] Frontmatter `prerequisites` / `relations[].target` slugs were sourced from the primary note's `Connections` section + §4 citation-graph candidates, NOT taken from the body string Sonnet returned.
 
 ## Notes on cache file fidelity
 

--- a/.claude/skills/algo-page/references/algo-page-template-historical.md
+++ b/.claude/skills/algo-page/references/algo-page-template-historical.md
@@ -40,7 +40,6 @@ relations:
 # Optional
 difficulty: <beginner|intermediate|advanced>
 draft: false
-relatedAlgorithms: ["<algo-slug>"]   # OK if a genuine pipeline link exists; do NOT list the successor here (it lives on `relations[]`)
 prerequisites: []                     # concept slugs this method depends on; keep only if still load-bearing
 sources:
   primary: <paper-id>                 # the original paper's id from docs/papers/index.yaml
@@ -48,9 +47,13 @@ sources:
   notes: |
     Brief reasoning substrate (optional). Same shape as canonical pages.
 
+# A genuine pipeline link is OK as an additional `relations[]` entry
+# (e.g. `type: feeds_into`); do NOT list the successor there — that
+# relationship is the required `generalized_by` entry above.
+
 # Forbidden on historical pages
-# editorAlgorithmId: ...   ← drop entirely; no Try-in-editor CTA
-# comparedWith: [...]      ← drop entirely; supersession is not comparison (CLAUDE.md → Rule A)
+# editorAlgorithmId: ...                        ← drop entirely; no Try-in-editor CTA
+# relations[type=compared_with]: [...]          ← drop entirely; supersession is not comparison (CLAUDE.md → Rule A)
 ---
 
 # Goal

--- a/.claude/skills/algo-page/references/algo-page-template.md
+++ b/.claude/skills/algo-page/references/algo-page-template.md
@@ -11,7 +11,6 @@ author: "Vitaly Vorobyev"
 difficulty: <beginner|intermediate|advanced>
 draft: false
 relatedPosts: ["<blog-slug>"]
-relatedAlgorithms: ["<algo-slug>"]
 relatedDemos: ["<demo-slug>"]
 editorAlgorithmId: <chess-corners|chessboard|charuco|markerboard|ringgrid|radsym>
 coverImage: "./images/<slug>/cover.png"
@@ -20,8 +19,15 @@ demoLinks: ["https://..."]
 
 # Atlas relationship fields (optional)
 prerequisites: []   # concept slugs this algorithm depends on
-comparedWith: []    # algorithms that this is directly contrasted with (author one side; build mirrors)
 failureModes: []    # failure-mode page slugs (always empty in MVP)
+
+# Quality + typed relations (optional) — see CLAUDE.md → "Relations field"
+quality: <stub|canonical|historical>
+relations:
+  - type: <generalized_by|alternative_formulation_of|parallel_foundation_with|extended_by|compared_with|feeds_into|learned_alternative_of>
+    target: <slug>
+    confidence: <high|medium|low>
+    caution: "<one-line note, optional>"
 ---
 
 # Goal

--- a/.claude/skills/concept-page/SKILL.md
+++ b/.claude/skills/concept-page/SKILL.md
@@ -86,9 +86,16 @@ category: ...            # image-formation | geometry | feature-theory | calibra
 
 # Optional relationship fields
 prerequisites: []        # concept slugs this concept depends on (often empty for primitives)
-related: [...]           # algorithm/model slugs that genuinely use this concept
-comparedWith: []         # rare for concepts; used when two formulations are directly contrasted
 failureModes: []         # always empty in MVP; required as placeholder
+
+# Quality + typed relations (optional)
+quality: stub | canonical | historical    # see CLAUDE.md → "Quality field"
+relations:                                # see CLAUDE.md → "Relations field". The single field for all
+                                          # inter-page links beyond prerequisites/failureModes.
+  - type: generalized_by | alternative_formulation_of | parallel_foundation_with | extended_by | compared_with | feeds_into | learned_alternative_of
+    target: <slug>
+    confidence: high | medium | low
+    caution: <one-line note, optional>
 
 # Optional sources
 sources:
@@ -100,7 +107,7 @@ sources:
 
 **Source kinds.** `sources.primary` and `sources.references[]` accept `<bare-id>` (defaults to `paper`), `paper:<id>`, `repo:<url>@<sha>`, or `doc:<repo-relative-path>`. Concepts most often cite `paper:` and occasionally `doc:` (a textbook chapter, a foundational design doc); `repo:` is rare for concepts but accepted when the canonical reference for the concept is a repo (e.g. an algorithm whose only specification is a reference implementation).
 
-`category` is required. `related` is strongly recommended — a concept page with no `related` entries is not yet doing its job in the graph. `prerequisites` is often empty for primitive concepts (`image-gradient`, `homography`) but populated for derived ones.
+`category` is required. `prerequisites` (this concept's own dependencies) is often empty for primitive concepts (`image-gradient`, `homography`) but populated for derived ones. A concept page does not author outgoing links to the algorithm/model pages that use it — those pages list this concept's slug in *their own* `prerequisites`, and the build derives the reverse `usedBy` edge on this page automatically. `relations[]` is for concept-to-concept lineage only (e.g. two alternative formulations of the same idea), not for linking out to dependents.
 
 **Do not write `usedBy:` or any reverse field.** Reverse edges are derived by the build.
 
@@ -108,7 +115,13 @@ sources:
 
 ### Step 1 — Page-creation criterion check
 
-Evaluate the criterion before doing anything else. Count how many existing `content/algorithms/` and `content/models/` pages list the concept slug in their `prerequisites` field. Count planned pages from any open research notes. If the count is below 3, reject. If the planned content is too narrow for 500 words, reject.
+Evaluate the criterion from `## Page-creation criterion` above before doing anything else — do not proxy it with a referencing-page count. Check, in order:
+
+1. **Fundamental and cross-cutting.** The topic is a genuinely fundamental, cross-cutting computer-vision concept — not one that happens to be reused, but one that would deserve a page even before its dependents exist. The number of pages that currently (or will eventually) reference the concept is **not** a gate.
+2. **≥500 words of substance.** The topic can support at least 500 words of substantive standalone content across the five required sections (definition, math, numerical concerns, implementation implications, where it appears).
+3. **Source diversity (the real second gate).** The concept can synthesise ≥3 distinct sources — check `docs/research/notes/` for existing notes and confirm at least 3 will be cited (see Step 2 and Step 4). A topic backed by a single paper belongs as a section inside that paper's page, not as a standalone concept.
+
+If (1) fails, the topic is probably too peripheral — prefer to defer it. If (2) or (3) fails, **reject the request**: suggest adding it as a `## <Concept>` subsection inside the most relevant existing algorithm or model page instead.
 
 ### Step 2 — Confirm required research notes exist
 
@@ -151,7 +164,7 @@ Additionally check the multi-source rule: at least 3 of the 5 sections must draw
 
 ### Step 5.6 — Assemble and write
 
-Opus assembles `--- frontmatter --- \n <body string from Sonnet>` and calls `Write` once. Frontmatter `related` slugs come from the notes' `Connections` sections + the candidate page slugs that listed this concept in their `prerequisites` (from Step 1's count), NOT from the body string.
+Opus assembles `--- frontmatter --- \n <body string from Sonnet>` and calls `Write` once. Frontmatter `prerequisites` (this concept's own dependencies on other concepts) and any `relations[]` entries (concept-to-concept lineage, e.g. `alternative_formulation_of`) come from the notes' `Connections` sections, NOT from the body string. Do not add a forward link to the algorithm/model pages that use this concept — those pages carry it in their own `prerequisites`, and the build derives this page's `usedBy` bucket automatically.
 
 ### Step 6 — Verify
 
@@ -171,7 +184,7 @@ Inherit the full `algo-page` forbidden-patterns list. The following are concept-
 - **No "fundamental to all of computer vision" openers.** The `# Definition` section begins with a precise statement of what the concept is, not with a claim about its importance.
 - **No paraphrase of the `# Definition` as the opening sentence of `# Mathematical Description`.** The definition is already stated; `# Mathematical Description` develops it.
 - **No Wikipedia-style "history of" paragraphs** — attribution lives in `# References`.
-- **No pairwise concept comparisons as standalone pages.** Use `comparedWith:` field + inline `## When X vs Y` subsection.
+- **No pairwise concept comparisons as standalone pages.** Use `relations[type=compared_with]` + inline `## When X vs Y` subsection.
 - **Loading the paper cache file (`docs/papers/.cache/*.{html,txt}`) into the orchestrator's context.** All paper reads happen in the Sonnet Extract contract during paper-ingest; the orchestrator works from notes only.
 
 ## Checklist
@@ -185,7 +198,7 @@ Run before handing off a draft.
 - [ ] `# Numerical Concerns` covers at least floating-point behavior and scale sensitivity (when applicable).
 - [ ] `# Where it appears` names specific registered page slugs.
 - [ ] `# References` is a numbered list, 1–5 entries.
-- [ ] Frontmatter: `category` present and valid. `related` populated.
+- [ ] Frontmatter: `category` present and valid. `prerequisites` reflects this concept's own dependencies (often empty for primitives); no forward link authored to dependent algorithm/model pages.
 - [ ] At least 3 of the 5 sections draw from ≥2 distinct sources.
 - [ ] No first-person pronouns anywhere on the page.
 - [ ] No `usedBy:` or any reverse field in frontmatter.

--- a/.claude/skills/deep-model-page/SKILL.md
+++ b/.claude/skills/deep-model-page/SKILL.md
@@ -132,7 +132,6 @@ flops: "4.1 GMAC @ 224×224"  # canonical config — human-readable
 difficulty: intermediate     # beginner | intermediate | advanced
 draft: false
 relatedPosts: [...]          # Blog post slugs
-relatedAlgorithms: [...]     # Algorithm page slugs (for hybrid pipelines)
 relatedDemos: [...]          # Demo page slugs
 coverImage: "..."
 ```
@@ -160,10 +159,10 @@ The note's `## NEW: <slug>` or `## UPDATE: <slug>` block provides authoritative 
 **Explicit rules:**
 
 - **1:1 page = primary paper (or paper family).** Every model page has exactly one primary paper in `sources.primary`. Supplementary papers go in `sources.references` only.
-- **No pairwise comparison pages.** Use `comparedWith:` field + an inline `## When to choose X over Y` section in the more authoritative page. Surveys allowed only with ≥3 methods, ≥800 words, and a decision table.
+- **No pairwise comparison pages.** Use `relations[type=compared_with]` + an inline `## When to choose X over Y` section in the more authoritative page. Surveys allowed only with ≥3 methods, ≥800 words, and a decision table.
 - **Never publish raw LLM summaries.** Always synthesize against the research note's structured fields and your own understanding. Each claim must trace to a paper section, equation, table, or impl file/line.
 - **Cite source IDs only from `docs/papers/index.yaml`.** Do not invent paper IDs.
-- **Never reference unresolved slugs.** Verify every slug in `relatedAlgorithms`, `prerequisites`, `comparedWith` exists on disk before adding it.
+- **Never reference unresolved slugs.** Verify every slug in `relations[].target` and `prerequisites` exists on disk before adding it.
 - **Do not author reverse edges.** `usedBy:` and similar reverse fields are computed by the build. Never add them manually.
 - Use `quality: stub` only for intentional public placeholders; `quality: canonical` only when the canonical gate is satisfied.
 
@@ -196,7 +195,7 @@ B8. **Synthesize the frontmatter — sources, category, and header metadata.** N
    - `title` (display name, quoted), `date: <today>`, `summary` (one sentence: what the model takes in, produces, and how it is trained), `tags` (at least `computer-vision` + primary task), `category` (one of the six vision-domain values), `difficulty: intermediate` unless clearly another tier, `author: "Vitaly Vorobyev"`.
    - `sources.primary`, `sources.references` (curated in B4 + cross-link candidates from `bun papers:query pages-using <ref-id>`), `sources.notes` (key equations / losses / table references grounding the page).
    - `arch_family`, `params`, `flops` if the paper reports them. Use the canonical configuration the paper tables compare against.
-   - `relatedAlgorithms` / `relatedPosts` as applicable.
+   - `relations[]` cross-links (e.g. `learned_alternative_of` to the classical algorithm this model replaces) / `relatedPosts` as applicable.
    - **Omit `implementations` for now; it is filled in B9a.**
 
 B9. **Write `content/models/<slug>.md`** with the frontmatter above — no body, no `implementations` yet. This file will not validate as a non-draft until B9a completes; set `draft: true` temporarily if running a build during Bootstrap.
@@ -240,7 +239,7 @@ B10. **Flip `draft: false`** once B9a wrote at least one valid implementations e
    - `curl -fLsI <repo>` returns 200/301.
    - `curl -fLs https://raw.githubusercontent.com/<owner>/<repo>/<commit>/LICENSE | head -3` returns the recorded license header.
    - If the repo has moved, rewritten history, or changed license: update the entry (or remove it with a note in working notes).
-4. **Query the citation graph** (lightweight, in-orchestrator). `bun papers:query cites <primary-id>` and `bun papers:query pages-using <ref-id>` for each reference — used to populate `relatedAlgorithms` candidates. Output is small (slug list).
+4. **Query the citation graph** (lightweight, in-orchestrator). `bun papers:query cites <primary-id>` and `bun papers:query pages-using <ref-id>` for each reference — used to populate `relations[]` cross-link candidates. Output is small (slug list).
 5. **Read frontmatter of candidate cross-link pages.** For each candidate slug from §4, read only the page's frontmatter (cheap, ~200 tokens each). Do not load page bodies. Use the frontmatter `summary` and `sources.primary` to confirm a cross-link makes sense.
 6. **Assemble the Draft contract input.** Collect: primary note path, reference note paths, implementations[] entries (with verified licenses from §3), page-template skeleton path (`references/deep-model-page-template.md`), target slug. **Opus does NOT read the notes themselves at this step** — the Draft subagent will. Pass the verified `implementations[]` data to Sonnet so the page text can refer to license/framework/role correctly.
 7. **Delegate the page draft to Sonnet.** Invoke the Draft contract from `.claude/skills/_shared/subagent-prompts.md` with the inputs from §6. Sonnet returns:
@@ -259,7 +258,7 @@ B10. **Flip `draft: false`** once B9a wrote at least one valid implementations e
    # Zero MISS lines = page faithfully copies from notes
    ```
    Additionally: every `license`, `weights_license`, `framework`, and `role` claim in the body must match the verified `implementations[]` entry from §3 — string-match. Any mismatch is a hallucination flag. In case of MISS, either extend the note and re-delegate, or reject the draft and re-delegate with a stricter prompt.
-9. **Assemble and write.** Opus assembles `--- frontmatter ---\n<body string from Sonnet>` and calls `Write` once. Frontmatter `relatedAlgorithms` slugs come from §4 candidates + the primary note's `Connections` section, NOT from the body string. Cross-check every slug against `knownSlugs` (read from `src/generated/content-graph.ts` or by listing `content/{algorithms,models,concepts}/`).
+9. **Assemble and write.** Opus assembles `--- frontmatter ---\n<body string from Sonnet>` and calls `Write` once. Frontmatter `relations[].target` slugs come from §4 candidates + the primary note's `Connections` section, NOT from the body string. Cross-check every slug against `knownSlugs` (read from `src/generated/content-graph.ts` or by listing `content/{algorithms,models,concepts}/`).
 10. **Verify.** `bun run build && bun run lint && npx vitest run`.
 
 ## Voice rules
@@ -315,8 +314,8 @@ For arxiv papers, `docs/papers/.cache/<id>.html` (ar5iv rendering) preserves LaT
 ## When not to use this skill
 
 - For **closed-form algorithms** (FAST, Harris, ChESS, non-maximum suppression, homography refinement), use `algo-page`. The `# Algorithm` section with defining formulas and per-pixel code is the right shape for those.
-- For **blog posts about a model** — history, intuition, comparison narrative, personal benchmarks — use `tech-writer`. Move the material to `content/blog/` and link back to the model page via `relatedModels`.
-- For **hybrid pipelines that combine a learned component with a classical algorithm** (e.g. SuperGlue on top of SuperPoint), pick the content type that dominates: if the page's primary contribution is the learned matcher's architecture, use `deep-model-page`; if it is the classical geometric verification, use `algo-page`. The other component goes in `sources.references` or `relatedAlgorithms` / `relatedModels`.
+- For **blog posts about a model** — history, intuition, comparison narrative, personal benchmarks — use `tech-writer`. Move the material to `content/blog/` and link back to the model page via the blog post's own `relatedAlgorithms` field (untyped; accepts any atlas slug — algorithm, model, or concept).
+- For **hybrid pipelines that combine a learned component with a classical algorithm** (e.g. SuperGlue on top of SuperPoint), pick the content type that dominates: if the page's primary contribution is the learned matcher's architecture, use `deep-model-page`; if it is the classical geometric verification, use `algo-page`. The other component goes in `sources.references` or as a `relations[]` cross-link (e.g. `learned_alternative_of`, `feeds_into`).
 
 ## Resources
 

--- a/.claude/skills/deep-model-page/references/deep-model-page-template.md
+++ b/.claude/skills/deep-model-page/references/deep-model-page-template.md
@@ -41,7 +41,6 @@ flops: "<4.1 GMAC @ 224×224 | 17.6 GMAC @ 1024×1024 | ...>"
 difficulty: <beginner|intermediate|advanced>
 draft: false
 relatedPosts: ["<blog-slug>"]
-relatedAlgorithms: ["<algo-slug>"]
 relatedDemos: ["<demo-slug>"]
 coverImage: "./images/<slug>/cover.png"
 ---

--- a/content/algorithms/apap-image-stitching.md
+++ b/content/algorithms/apap-image-stitching.md
@@ -7,7 +7,7 @@ domain: stitching
 tasks: [image-stitching]
 author: "Vitaly Vorobyev"
 difficulty: advanced
-prerequisites: [homography, dlt-normalisation, ransac]
+prerequisites: [homography, dlt-normalisation, ransac, spatially-varying-image-stitching]
 failureModes: []
 sources:
   primary: zaragoza2013-apap

--- a/content/algorithms/gao-dual-homography-stitching.md
+++ b/content/algorithms/gao-dual-homography-stitching.md
@@ -8,7 +8,7 @@ tasks: [image-stitching]
 author: "Vitaly Vorobyev"
 difficulty: intermediate
 quality: historical
-prerequisites: [homography, ransac, svd-null-space]
+prerequisites: [homography, ransac, svd-null-space, spatially-varying-image-stitching]
 failureModes: []
 relations:
   - type: generalized_by

--- a/content/algorithms/lin-sva-stitching.md
+++ b/content/algorithms/lin-sva-stitching.md
@@ -7,7 +7,7 @@ domain: stitching
 tasks: [image-stitching]
 author: "Vitaly Vorobyev"
 difficulty: advanced
-prerequisites: [homography, ransac]
+prerequisites: [homography, ransac, spatially-varying-image-stitching]
 failureModes: []
 relations:
   - type: generalized_by

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ If you only have time for one section, read **§6 Workflow at a glance**.
 
 ## 1. What the atlas is
 
-`vitavision.dev/algorithms` is a connected **practical computer vision atlas**: short reference cards for algorithms, models, and concepts, cross-linked by a typed relationship graph (prerequisites, related, compared-with, used-by, failure-modes). The atlas is intentionally curated — depth and correctness over coverage. Public pages are source-grounded and machine-checked; private research notes carry the reasoning substrate that backs the public content.
+`vitavision.dev/algorithms` is a connected **practical computer vision atlas**: short reference cards for algorithms, models, and concepts, cross-linked by a typed relationship graph (prerequisites, typed `relations[]`, used-by, failure-modes). The atlas is intentionally curated — depth and correctness over coverage. Public pages are source-grounded and machine-checked; private research notes carry the reasoning substrate that backs the public content.
 
 Public site lives at:
 - `/algorithms` — the atlas index (heading: "Atlas"; URL kept stable for SEO).
@@ -218,7 +218,7 @@ Type-specific fields (`category` enum, `editorAlgorithmId`, model `implementatio
 
 ## 11. Atlas vault — graph view in Obsidian
 
-`docs/atlas-vault/` is a generated Obsidian-compatible projection of the atlas. Every algorithm, model, concept, and paper becomes a stub `.md` whose body is `[[wikilinks]]` for every forward edge — useful for opening in Obsidian and looking at the atlas as a graph (clusters by shared concepts, by `comparedWith`, by paper citations).
+`docs/atlas-vault/` is a generated Obsidian-compatible projection of the atlas. Every algorithm, model, concept, and paper becomes a stub `.md` whose body is `[[wikilinks]]` for every forward edge — useful for opening in Obsidian and looking at the atlas as a graph (clusters by shared concepts, by `relations[]`, by paper citations).
 
 ```bash
 bun run vault:build       # regenerate docs/atlas-vault/ from content/** + docs/papers/index.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Pairwise pages are prohibited. A survey of ≥3 methods lives as a **concept pag
 - ≥3 surveyed methods.
 - ≥800 words of substantive content.
 - A decision table near the top (rows = methods, columns = "use when / avoid when / typical cost / typical accuracy").
-- Each surveyed algorithm page references the survey concept via a `relations[]` entry (so the relationship panel surfaces it from each method's page).
+- Each surveyed algorithm page lists the survey concept in its `prerequisites` (so the build derives a `usedBy` backlink and the relationship panel surfaces it from each method's page). Not `relations[]` — that field excludes prerequisites, and its type vocabulary is method-to-method with no type expressing survey membership.
 
 ### Agentic discipline
 

--- a/docs/content-authoring.md
+++ b/docs/content-authoring.md
@@ -132,7 +132,14 @@ coverImage: "/content/images/my-cover.jpg"
 repoLinks: ["https://github.com/user/repo"]
 demoLinks: ["https://vitavision.dev/editor"]
 relatedPosts: ["02-my-topic"]
-relatedAlgorithms: ["another-algorithm"]
+# Atlas relationship fields (optional; single global slug namespace across
+# algorithms, models, and concepts — see CLAUDE.md → "Atlas authoring policy"):
+prerequisites: ["homography"]     # concept/algorithm/model slugs this page depends on
+quality: canonical                # stub | canonical | historical
+relations:                        # typed inter-page links — see CLAUDE.md → "Relations field"
+  - type: compared_with
+    target: another-algorithm
+    confidence: high
 ---
 ```
 

--- a/docs/research/notes/detone2018-superpoint.md
+++ b/docs/research/notes/detone2018-superpoint.md
@@ -169,14 +169,21 @@ sources:
   primary: detone2018-superpoint
   references:
     - rosten2006-fast
-relatedAlgorithms:
-  - harris-corner-detector
-  - shi-tomasi-corner-detector
-  - fast-corner-detector
-comparedWith:
-  - xfeat
+relations:
+  - type: learned_alternative_of
+    target: harris-corner-detector
+    confidence: high
+  - type: learned_alternative_of
+    target: shi-tomasi-corner-detector
+    confidence: high
+  - type: learned_alternative_of
+    target: fast-corner-detector
+    confidence: medium
+  - type: compared_with
+    target: xfeat
+    confidence: high
 ```
-Note: `comparedWith: [xfeat]` — the xfeat page (2024) references SuperPoint (2018); SuperPoint is the older paper, so SuperPoint hosts the comparison per the "older paper hosts" tiebreaker. However, since `content/models/xfeat.md` already exists as a draft, confirm whether a comparison section belongs on the `superpoint` page or is deferred until both pages are non-draft.
+Note: `relations[type=compared_with, target=xfeat]` — the xfeat page (2024) references SuperPoint (2018); SuperPoint is the older paper, so SuperPoint hosts the comparison per the "older paper hosts" tiebreaker. However, since `content/models/xfeat.md` already exists as a draft, confirm whether a comparison section belongs on the `superpoint` page or is deferred until both pages are non-draft.
 
 ## UPDATE: xfeat (supplementary)
 

--- a/docs/research/notes/laureano2013-topological.md
+++ b/docs/research/notes/laureano2013-topological.md
@@ -183,7 +183,7 @@ The Shu page already lists the `laureano2013-topological` paper in its coverage 
 - **When a quad-level topological abstraction is preferred:** Shu merges triangles into quads first, then filters; Laureano filters at the triangle level. The quad representation directly models the chessboard tile topology.
 - **When Laureano is preferred over Shu:** partial occlusion support without orientation markers; per-pixel x-corner detector avoids Harris's threshold sensitivity; Chen-Zhang Hessian subpixel refinement is more principled than Harris's own subpixel output; iterative fixed-point filter is more aggressive at removing marginal triangles than Shu's single-pass degree-pruning.
 
-Add `comparedWith: [laureano-topological-chessboard]` to the Shu page frontmatter (Shu is the host).
+Add `relations: [{ type: compared_with, target: laureano-topological-chessboard, confidence: high }]` to the Shu page frontmatter (Shu is the host).
 
 ---
 

--- a/docs/research/notes/potje2024-xfeat.md
+++ b/docs/research/notes/potje2024-xfeat.md
@@ -135,9 +135,9 @@ The existing `content/models/xfeat.md` page is substantive and well-grounded. Th
 
 - Once `content/models/superpoint.md` exists as a non-draft, add entry 2 for SuperPoint (replacing any placeholder). As the direct architectural ancestor, it warrants explicit placement in the reference list. The current page already cites DeTone 2018 as reference entry 2.
 
-### Comparison policy — `comparedWith:` field
+### Comparison policy — `relations[type=compared_with]`
 
-The `xfeat` page's `comparedWith: []` is currently empty. The most important comparison edge is `xfeat ↔ superpoint`:
+The `xfeat` page currently has no `compared_with` entry in `relations[]`. The most important comparison edge is `xfeat ↔ superpoint`:
 - SuperPoint is the older paper (2018 vs. 2024) → SuperPoint hosts the `## When to choose SuperPoint over XFeat` section, per the "older paper hosts" tiebreaker.
 - Preconditions for authoring comparison content: `docs/research/notes/detone2018-superpoint.md` ✓ exists; `docs/research/notes/potje2024-xfeat.md` ✓ exists (this note). Both required research notes are now present — the comparison section can be written when the `superpoint` model page is authored.
 - The non-host page (`xfeat`) should carry a single Remarks bullet: "Compared with SuperPoint: see [When to choose SuperPoint over XFeat](/atlas/superpoint#when-to-choose-superpoint-over-xfeat). SuperPoint hosts the comparison as the older paper."

--- a/src/generated/content-graph.ts
+++ b/src/generated/content-graph.ts
@@ -1041,7 +1041,8 @@ export const contentGraph: ContentGraph = {
       "prerequisites": [
         "homography",
         "dlt-normalisation",
-        "ransac"
+        "ransac",
+        "spatially-varying-image-stitching"
       ],
       "failureModes": [],
       "relations": []
@@ -1279,7 +1280,8 @@ export const contentGraph: ContentGraph = {
       "prerequisites": [
         "homography",
         "ransac",
-        "svd-null-space"
+        "svd-null-space",
+        "spatially-varying-image-stitching"
       ],
       "failureModes": [],
       "relations": [
@@ -1497,7 +1499,8 @@ export const contentGraph: ContentGraph = {
     "lin-sva-stitching": {
       "prerequisites": [
         "homography",
-        "ransac"
+        "ransac",
+        "spatially-varying-image-stitching"
       ],
       "failureModes": [],
       "relations": [
@@ -5040,7 +5043,11 @@ export const contentGraph: ContentGraph = {
       "hasLearnedAlternative": []
     },
     "spatially-varying-image-stitching": {
-      "usedBy": [],
+      "usedBy": [
+        "apap-image-stitching",
+        "gao-dual-homography-stitching",
+        "lin-sva-stitching"
+      ],
       "affects": [],
       "generalises": [],
       "extending": [],
@@ -5107,7 +5114,8 @@ export const contentGraph: ContentGraph = {
     "svd-null-space": 0,
     "homography": 1,
     "dlt-normalisation": 1,
-    "apap-image-stitching": 2,
+    "spatially-varying-image-stitching": 2,
+    "apap-image-stitching": 3,
     "convolution": 0,
     "image-gradient": 1,
     "scale-space": 1,
@@ -5136,7 +5144,7 @@ export const contentGraph: ContentGraph = {
     "epipolar-geometry": 2,
     "stereo-rectification": 3,
     "fusiello-compact-rectification": 4,
-    "gao-dual-homography-stitching": 2,
+    "gao-dual-homography-stitching": 3,
     "geiger-chessboard-detector": 2,
     "ni-generalized-fast-radial-symmetry": 2,
     "convolutional-neural-network": 1,
@@ -5150,7 +5158,7 @@ export const contentGraph: ContentGraph = {
     "horn-schunck": 4,
     "camera-distortion-models": 1,
     "kumar-generalized-rac": 2,
-    "lin-sva-stitching": 2,
+    "lin-sva-stitching": 3,
     "duda-radon-corners": 2,
     "longuet-higgins-eight-point": 3,
     "loop-zhang-rectification": 4,
@@ -5223,7 +5231,6 @@ export const contentGraph: ContentGraph = {
     "vgg": 2,
     "vggt": 4,
     "xfeat": 2,
-    "yolo-v1": 0,
-    "spatially-varying-image-stitching": 2
+    "yolo-v1": 0
   }
 };

--- a/src/generated/content-index.ts
+++ b/src/generated/content-index.ts
@@ -78,7 +78,8 @@ export const algorithmPages: AlgorithmIndexEntry[] = [
       "prerequisites": [
         "homography",
         "dlt-normalisation",
-        "ransac"
+        "ransac",
+        "spatially-varying-image-stitching"
       ],
       "failureModes": [],
       "tags": [
@@ -629,7 +630,8 @@ export const algorithmPages: AlgorithmIndexEntry[] = [
       "prerequisites": [
         "homography",
         "ransac",
-        "svd-null-space"
+        "svd-null-space",
+        "spatially-varying-image-stitching"
       ],
       "failureModes": [],
       "quality": "historical",
@@ -1121,7 +1123,8 @@ export const algorithmPages: AlgorithmIndexEntry[] = [
       "access": "public",
       "prerequisites": [
         "homography",
-        "ransac"
+        "ransac",
+        "spatially-varying-image-stitching"
       ],
       "failureModes": [],
       "relations": [


### PR DESCRIPTION
The content tree migrated to `relations[]` + `prerequisites` a while back; the authoring docs did not. Every authoring run has been reading instructions for fields that no longer exist, and **a page scaffolded verbatim from any of the three templates failed validation**.

Ground truth (`src/lib/content/schema.ts`): `related` and `comparedWith` are absent from every schema. `relatedAlgorithms` survives on **blog and demo** frontmatter only — so it is deliberately left alone there, not swept.

## Two substantive corrections beyond the field renames

**1. `concept-page` Step 1 enforced the opposite of current policy.** It said *"count how many pages list the concept slug in their `prerequisites`; if the count is below 3, reject"* — while CLAUDE.md says "the number of pages referencing the concept is **not** a gate". The skill already stated the correct rule in its header, so it contradicted itself, and Step 1 won in practice because it's the executable step. (This is the gate that had to be overridden by hand last session.)

Rewritten to the real criterion: fundamental + cross-cutting, ≥500 words, ≥3 distinct **sources**. Source diversity was the missing second gate.

**2. Clarified that a concept page never authors outgoing links to its dependents.** Dependent pages carry the concept in their own `prerequisites`; the build derives `usedBy`. `relations[]` on a concept is for concept-to-concept lineage only.

## Survey wiring — `prerequisites`, not `relations[]`

CLAUDE.md said surveyed algorithms list the survey in `related`. The correct field is **`prerequisites`**: `relations[]` explicitly excludes prerequisites, and its type vocabulary is method-to-method with no type expressing survey membership. The stereo-rectification cluster already does it this way.

Applied to the orphaned survey — `content/concepts/spatially-varying-image-stitching.md` had **zero** graph backlinks:

```
usedBy: "apap-image-stitching", "gao-dual-homography-stitching", "lin-sva-stitching"
```

Acyclic — the survey's own prerequisites are `[homography, ransac]`.

## ⚠️ Also fixes a false claim — and documents a real CI gap

CLAUDE.md's Validation section said *"The build runs the same validation"*. **It does not, and neither does CI.**

- `bun run build` → `content:build && atlas:layout && tsc -b && vite build` — no validator.
- CI's `validate-content` job runs `bun run content:validate` → `scripts/content-validate.ts`, which only checks blog/algorithm internal links and `relatedPosts`.
- `scripts/validate-content.ts` — the real Atlas graph validator (unknown slugs in `relations[].target`, prerequisite cycles, source-id existence, canonical gates) — **is run by nothing automated.**

So a broken `relations[].target` slug or a prerequisite cycle currently passes CI. Documented rather than papered over; closing the gap is a follow-up.

## Verification

```
bun run scripts/validate-content.ts    ✓ 122 pages (51 algo, 42 model, 29 concept), no errors
bun run build                          ✓ 131 static pages
bun run lint                           ✓ clean
npx vitest run                         ✓ 26 files, 277 tests
```

Acceptance test: a throwaway page scaffolded from each of the three templates now passes validation — they previously did not.

## Follow-ups found, not in this PR

- **`scripts/atlas-vault-build.ts` has a real bug** — reads `fm.related` / `fm.relatedAlgorithms` / `fm.comparedWith` (L84–85, L94), all dead. `bun run vault:build` silently emits empty sections.
- **`.claude/AGENTS.md`** is a full duplicate policy doc still describing the entire pre-migration field model, with no `relations[]` at all.
- 11 more `docs/research/notes/*.md` carry the same drift in their Atlas-update plans.
- `src/hooks/useAtlasGraph.ts:41` JSDoc only (logic is already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwFzcPMcsqkG1PCLcgg2as