### PR TITLE
ci: gate the Atlas graph validator, and fix the vault builder's dead fields

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -137,11 +137,13 @@ Run `bun run scripts/validate-content.ts` **by path** before opening a PR. It ch
 resolution (including `relations[].target`), prerequisite cycles, source-id existence, and
 canonical-quality gates.
 
-Nothing automated runs it. `bun run build` does not, and CI's `validate-content` job runs
-`bun run content:validate` → `scripts/content-validate.ts`, a different and much narrower
-script that only checks blog/algorithm internal links and `relatedPosts`. So a broken
-`relations[].target` slug or a prerequisite cycle will pass CI. Until that gap is closed,
-the manual run is the only gate — do not skip it.
+CI's `validate-content` job runs both scripts: `bun run content:validate` →
+`scripts/content-validate.ts` (narrower — blog/algorithm internal links and
+`relatedPosts` only), and `bun run scripts/validate-content.ts` by path (the real
+Atlas graph validator described above). The two script names are confusingly
+similar but cover different ground — don't assume one supersedes the other, and
+don't remove either without replacing its coverage. `bun run build` still does not
+run either validator, so a local build succeeding is not proof content is valid.
 
 ### Research notes (unpublished reasoning substrate)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,19 @@ jobs:
       - name: Install
         run: bun install --frozen-lockfile
 
-      - name: Validate content
+      # NOTE: `content:validate` and `scripts/validate-content.ts` are two
+      # different scripts with different coverage — the similar names are a
+      # known trap (see .claude/CLAUDE.md → "Validation"). `content:validate`
+      # (scripts/content-validate.ts) checks blog/algorithm markdown links and
+      # `relatedPosts`. `scripts/validate-content.ts` is the real Atlas graph
+      # validator — slug resolution (including `relations[].target`),
+      # prerequisite cycles, source-id existence, canonical-quality gates.
+      # Run by explicit path so the distinction stays unmissable in the log.
+      - name: Validate content (blog/demo links)
         run: bun run content:validate
+
+      - name: Validate content (Atlas graph)
+        run: bun run scripts/validate-content.ts
 
   # ── Frontend: lint + build ────────────────────────────────────────────────
   build-frontend:

--- a/docs/atlas-vault/README.md
+++ b/docs/atlas-vault/README.md
@@ -8,16 +8,17 @@
 
 An Obsidian-compatible projection of the atlas — every algorithm, model,
 concept, and paper is a stub `.md` whose body contains `[[wikilinks]]` for
-every forward edge (prerequisites, related, comparedWith, failureModes,
-sources, paper→paper citations). Open this folder as a vault in Obsidian
-and use the graph view to look for clusters, gaps, and isolated islands.
+every forward edge (prerequisites, typed relations — grouped as Lineage /
+Practice / Cross-paradigm, failureModes, sources, paper→paper citations).
+Open this folder as a vault in Obsidian and use the graph view to look
+for clusters, gaps, and isolated islands.
 
 ## Counts
 
-- Algorithms: 24
-- Models: 4
-- Concepts: 11
-- Papers: 38
+- Algorithms: 52
+- Models: 42
+- Concepts: 29
+- Papers: 115
 
 ## Conventions
 

--- a/docs/atlas-vault/algorithms/02-demo-blocks.md
+++ b/docs/atlas-vault/algorithms/02-demo-blocks.md
@@ -7,7 +7,3 @@ slug: 02-demo-blocks
 > Generated stub — do not edit. Source: `content/algorithms/02-demo-blocks.md`.
 
 A draft algorithm page that exercises semantic blocks, math, diagrams, code, and related-link metadata.
-
-## Related
-
-- [[harris-corner-detector]]

--- a/docs/atlas-vault/algorithms/apap-image-stitching.md
+++ b/docs/atlas-vault/algorithms/apap-image-stitching.md
@@ -12,11 +12,8 @@ Replace a global homography with a spatially varying field of homographies, each
 
 - [[dlt-normalisation]]
 - [[homography]]
-
-## Related
-
+- [[ransac]]
 - [[spatially-varying-image-stitching]]
-- [[zhang-planar-calibration]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/barath-magsac.md
+++ b/docs/atlas-vault/algorithms/barath-magsac.md
@@ -1,0 +1,17 @@
+---
+title: "MAGSAC: Marginalising Sample Consensus"
+type: algorithm
+slug: barath-magsac
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/barath-magsac.md`.
+
+Robust estimator that eliminates the user-tuned inlier threshold by treating the noise scale σ as a random variable on [0, σ_max] and marginalising the RANSAC quality function over σ; the final model is a weighted least-squares fit using marginal-likelihood weights via iteratively reweighted least squares (σ-consensus).
+
+## Prerequisites
+
+- [[ransac]]
+
+## Sources
+
+- Primary: [[barath2019-magsac]]

--- a/docs/atlas-vault/algorithms/black-anandan-robust-flow.md
+++ b/docs/atlas-vault/algorithms/black-anandan-robust-flow.md
@@ -1,0 +1,21 @@
+---
+title: "Black-Anandan Robust Optical Flow"
+type: algorithm
+slug: black-anandan-robust-flow
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/black-anandan-robust-flow.md`.
+
+Optical flow that replaces the quadratic data and smoothness penalties of variational flow with redescending M-estimators, solved by SOR within a graduated non-convexity continuation; recovers piecewise-smooth flow without explicit line processes and a robust affine variant for multiple parametric motions.
+
+## Prerequisites
+
+- [[image-gradient]]
+- [[optical-flow]]
+- [[scale-space]]
+
+## Sources
+
+- Primary: [[black1996-robust]]
+- Reference: [[horn1981-horn-schunck]]
+- Reference: [[lucas1981-lucas-kanade]]

--- a/docs/atlas-vault/algorithms/brief.md
+++ b/docs/atlas-vault/algorithms/brief.md
@@ -1,0 +1,35 @@
+---
+title: "BRIEF: Binary Robust Independent Elementary Features"
+type: algorithm
+slug: brief
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/brief.md`.
+
+Encodes a Gaussian-smoothed image patch around a detected keypoint as a 128/256/512-bit binary string by running a fixed table of pairwise pixel-intensity tests; matched between images by Hamming distance via bitwise XOR + popcount.
+
+## Prerequisites
+
+- [[feature-descriptors]]
+- [[image-gradient]]
+- [[integral-image]]
+
+## Lineage
+
+- **Extended by** — [[orb]]
+  > rBRIEF steers BRIEF via a 30-bin orientation LUT and replaces the random offset table with 256 learned, low-correlation tests.
+
+## Practice
+
+- **Compared with** — [[sift]] _(confidence: medium)_
+  > BRIEF is descriptor-only; SIFT/SURF bundle a detector.
+- **Compared with** — [[surf]] _(confidence: medium)_
+  > BRIEF is descriptor-only; SIFT/SURF bundle a detector.
+
+## Sources
+
+- Primary: [[calonder2010-brief]]
+- Reference: [[bay2006-surf]]
+- Reference: [[lowe2004-sift]]
+- Reference: [[rosten2006-fast]]
+- Reference: [[viola2001-detector]]

--- a/docs/atlas-vault/algorithms/canny-edge-detector.md
+++ b/docs/atlas-vault/algorithms/canny-edge-detector.md
@@ -1,0 +1,19 @@
+---
+title: "Canny Edge Detector"
+type: algorithm
+slug: canny-edge-detector
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/canny-edge-detector.md`.
+
+Detect thin step edges in greyscale images by smoothing with a Gaussian, computing gradient magnitude and direction, suppressing non-maxima along the gradient direction, then linking surviving pixels via hysteresis double-thresholding; the filter shape is derived as the variational optimum of three criteria — detection SNR, localisation, and single-response spacing — under an additive-white-Gaussian-noise step-edge model.
+
+## Prerequisites
+
+- [[convolution]]
+- [[image-gradient]]
+- [[non-maximum-suppression]]
+
+## Sources
+
+- Primary: [[canny1986-edge]]

--- a/docs/atlas-vault/algorithms/chess-corners.md
+++ b/docs/atlas-vault/algorithms/chess-corners.md
@@ -12,19 +12,12 @@ A chessboard-specific corner detector: scores each pixel by how well its local n
 
 - [[image-gradient]]
 
-## Related
+## Practice
 
-- [[chessboard-x-corner-detection]]
-- [[fast-corner-detector]]
-- [[harris-corner-detector]]
-- [[shi-tomasi-corner-detector]]
-
-## Compared with
-
-- [[duda-radon-corners]]
-- [[puzzleboard]]
-- [[pyramidal-blur-aware-xcorner]]
-- [[rochade]]
+- **Compared with** — [[duda-radon-corners]]
+- **Compared with** — [[puzzleboard]]
+- **Compared with** — [[pyramidal-blur-aware-xcorner]]
+- **Compared with** — [[rochade]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/daniilidis-dual-quaternion-handeye.md
+++ b/docs/atlas-vault/algorithms/daniilidis-dual-quaternion-handeye.md
@@ -8,11 +8,6 @@ slug: daniilidis-dual-quaternion-handeye
 
 Solve the hand-eye equation AX=XB jointly for rotation and translation by parametrising rigid motions as unit dual quaternions and extracting X from the right null space of a single linear system.
 
-## Related
-
-- [[tsai-lenz-handeye]]
-- [[zhang-planar-calibration]]
-
 ## Sources
 
 - Primary: [[daniilidis1999-hand-eye]]

--- a/docs/atlas-vault/algorithms/duda-radon-corners.md
+++ b/docs/atlas-vault/algorithms/duda-radon-corners.md
@@ -12,14 +12,6 @@ Detect checkerboard X-junctions by approximating a localized Radon transform wit
 
 - [[image-gradient]]
 
-## Related
-
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[harris-corner-detector]]
-- [[pyramidal-blur-aware-xcorner]]
-- [[rochade]]
-
 ## Sources
 
 - Primary: [[duda2018-accurate]]

--- a/docs/atlas-vault/algorithms/epnp.md
+++ b/docs/atlas-vault/algorithms/epnp.md
@@ -1,0 +1,21 @@
+---
+title: "EPnP: O(n) Perspective-n-Point"
+type: algorithm
+slug: epnp
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/epnp.md`.
+
+Non-iterative O(n) solver for the calibrated Perspective-n-Point problem: express the n reference points as weighted sums of four virtual control points, recover their camera-frame coordinates from the null space of a 12×12 matrix, and extract pose by absolute orientation.
+
+## Prerequisites
+
+- [[dlt-normalisation]]
+- [[pinhole-camera-model]]
+- [[pose-estimation]]
+- [[ransac]]
+
+## Sources
+
+- Primary: [[lepetit2009-epnp]]
+- Reference: [[fischler1981-ransac]]

--- a/docs/atlas-vault/algorithms/fast-corner-detector.md
+++ b/docs/atlas-vault/algorithms/fast-corner-detector.md
@@ -11,12 +11,11 @@ Segment-test corner detector on a 16-pixel Bresenham ring of radius 3 around eac
 ## Prerequisites
 
 - [[image-gradient]]
+- [[non-maximum-suppression]]
 
-## Related
+## Practice
 
-- [[chess-corners]]
-- [[harris-corner-detector]]
-- [[shi-tomasi-corner-detector]]
+- **Feeds into** — [[orb]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/felzenszwalb-deformable-parts.md
+++ b/docs/atlas-vault/algorithms/felzenszwalb-deformable-parts.md
@@ -1,0 +1,24 @@
+---
+title: "Deformable Part Models"
+type: algorithm
+slug: felzenszwalb-deformable-parts
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/felzenszwalb-deformable-parts.md`.
+
+Detect a target object class in arbitrary images by scoring every position and scale in a HOG feature pyramid with a mixture of star-structured part-based templates — a coarse root filter and $n=6$ finer-resolution part filters with quadratic deformation costs — trained as a latent SVM with hard-negative mining.
+
+## Prerequisites
+
+- [[image-gradient]]
+
+## Practice
+
+- **Compared with** — [[viola-jones-detector]] _(confidence: medium)_
+  > Different operational regimes — VJ is real-time cascade for rigid faces; DPM is offline part-based for general deformable objects.
+
+## Sources
+
+- Primary: [[felzenszwalb2010-detection]]
+- Reference: [[dalal2005-hog]]
+- Reference: [[viola2001-detector]]

--- a/docs/atlas-vault/algorithms/felzenszwalb-graph-segmentation.md
+++ b/docs/atlas-vault/algorithms/felzenszwalb-graph-segmentation.md
@@ -1,0 +1,17 @@
+---
+title: "Felzenszwalb–Huttenlocher Graph-Based Image Segmentation"
+type: algorithm
+slug: felzenszwalb-graph-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/felzenszwalb-graph-segmentation.md`.
+
+Partition an image into perceptually coherent regions by a Kruskal-style greedy merge over a pixel graph, accepting an inter-component edge as a non-boundary when its weight does not exceed the components' internal variation plus a size-adaptive threshold $\tau(C) = k/|C|$; runs in $O(m \log m)$ time and produces partitions that are simultaneously not too fine and not too coarse.
+
+## Prerequisites
+
+- [[energy-minimization]]
+
+## Sources
+
+- Primary: [[felzenszwalb2004-graph-segm]]

--- a/docs/atlas-vault/algorithms/fischler-bolles-ransac.md
+++ b/docs/atlas-vault/algorithms/fischler-bolles-ransac.md
@@ -1,0 +1,24 @@
+---
+title: "Fischler–Bolles RANSAC"
+type: algorithm
+slug: fischler-bolles-ransac
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/fischler-bolles-ransac.md`.
+
+Founding random-sample-consensus paradigm: fit a parametric model to data containing an unknown fraction of gross outliers by drawing minimal random subsets, instantiating candidate models, counting consensus inliers, and retaining the largest consensus set.
+
+## Prerequisites
+
+- [[ransac]]
+
+## Lineage
+
+- **Extended by** — [[barath-magsac]]
+  > MAGSAC marginalises the inlier threshold rather than fixing it — orthogonal axis to USAC's framework refactor
+- **Extended by** — [[raguram-usac]]
+  > USAC is a unifying engineering framework, not a single new technique
+
+## Sources
+
+- Primary: [[fischler1981-ransac]]

--- a/docs/atlas-vault/algorithms/fundamental-matrix-eight-point.md
+++ b/docs/atlas-vault/algorithms/fundamental-matrix-eight-point.md
@@ -13,11 +13,10 @@ Compute the fundamental matrix from n ≥ 8 point correspondences by conditionin
 - [[dlt-normalisation]]
 - [[epipolar-geometry]]
 - [[homography]]
-
-## Related
-
-- [[apap-image-stitching]]
+- [[ransac]]
+- [[svd-null-space]]
 
 ## Sources
 
 - Primary: [[hartley1997-eight-point]]
+- Reference: [[longuet-higgins1981-eight-point]]

--- a/docs/atlas-vault/algorithms/fusiello-compact-rectification.md
+++ b/docs/atlas-vault/algorithms/fusiello-compact-rectification.md
@@ -1,0 +1,28 @@
+---
+title: "Fusiello Compact Stereo Rectification"
+type: algorithm
+slug: fusiello-compact-rectification
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/fusiello-compact-rectification.md`.
+
+Calibrated Euclidean rectification that builds a new pair of projection matrices sharing a common orientation from the two known PPMs, yielding a per-image rectifying homography.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[pinhole-camera-model]]
+- [[pose-estimation]]
+- [[stereo-rectification]]
+
+## Practice
+
+- **Compared with** — [[hartley-projective-rectification]]
+  > Requires known projection matrices; the 1999 uncalibrated methods need only F.
+
+## Sources
+
+- Primary: [[fusiello2000-compact-rectification]]
+- Reference: [[hartley1999-projective-rectification]]
+- Reference: [[loop1999-rectifying-homographies]]
+- Reference: [[pollefeys1999-polar-rectification]]

--- a/docs/atlas-vault/algorithms/gao-dual-homography-stitching.md
+++ b/docs/atlas-vault/algorithms/gao-dual-homography-stitching.md
@@ -6,20 +6,19 @@ slug: gao-dual-homography-stitching
 
 > Generated stub — do not edit. Source: `content/algorithms/gao-dual-homography-stitching.md`.
 
-Stitch two-plane outdoor panoramas by clustering SIFT correspondences into a ground group and a distant group via spatial K-means, fitting one homography per group with RANSAC, and blending per pixel by inverse-distance weights — the direct two-plane predecessor of APAP's continuous grid of per-cell homographies.
+Stitch two-plane outdoor panoramas by clustering SIFT correspondences into a ground group and a distant group via spatial K-means, fitting one homography per group, and blending per pixel by inverse-distance weights. Superseded for practical use by APAP's continuous per-cell grid.
 
 ## Prerequisites
 
 - [[homography]]
-
-## Related
-
-- [[apap-image-stitching]]
+- [[ransac]]
 - [[spatially-varying-image-stitching]]
+- [[svd-null-space]]
 
-## Compared with
+## Lineage
 
-- [[apap-image-stitching]]
+- **Generalised by** — [[apap-image-stitching]]
+  > APAP's continuous grid of per-cell homographies subsumes the two-plane parametrisation; the two methods are not peer practitioner choices.
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/geiger-chessboard-detector.md
+++ b/docs/atlas-vault/algorithms/geiger-chessboard-detector.md
@@ -12,16 +12,9 @@ Detect checkerboard X-corners by computing a four-quadrant corner likelihood at 
 
 - [[image-gradient]]
 
-## Related
+## Practice
 
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[pyramidal-blur-aware-xcorner]]
-- [[rochade]]
-
-## Compared with
-
-- [[pyramidal-blur-aware-xcorner]]
+- **Compared with** — [[pyramidal-blur-aware-xcorner]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/geometric-bev.md
+++ b/docs/atlas-vault/algorithms/geometric-bev.md
@@ -1,0 +1,20 @@
+---
+title: "Geometric Bird's-Eye-View Rectification"
+type: algorithm
+slug: geometric-bev
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/geometric-bev.md`.
+
+Rectifies a monocular image to a metric overhead (bird's-eye) view by constructing the rectifying homography in closed form from two CNN-regressed projective entities — the vertical vanishing point and the ground-plane horizon line.
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+- [[homography]]
+- [[pinhole-camera-model]]
+
+## Sources
+
+- Primary: [[abbas2019-bev]]
+- Reference: [[he2016-resnet]]

--- a/docs/atlas-vault/algorithms/gp-checkerboard-enhancement.md
+++ b/docs/atlas-vault/algorithms/gp-checkerboard-enhancement.md
@@ -12,11 +12,9 @@ Post-process a partially detected checkerboard by training two Gaussian processe
 
 - [[image-gradient]]
 
-## Related
+## Practice
 
-- [[chessboard-x-corner-detection]]
-- [[geiger-chessboard-detector]]
-- [[ocpad]]
+- **Compared with** — [[ocpad]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/grabcut-iterative-segmentation.md
+++ b/docs/atlas-vault/algorithms/grabcut-iterative-segmentation.md
@@ -1,0 +1,18 @@
+---
+title: "GrabCut Iterative Segmentation"
+type: algorithm
+slug: grabcut-iterative-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/grabcut-iterative-segmentation.md`.
+
+Extract a foreground from a colour image using a single bounding rectangle as the only required input by alternating Gaussian mixture component assignment, GMM parameter re-estimation, and global s-t min-cut on a contrast-weighted MRF — the iteration decreases a Gibbs energy $E(\alpha, k, \theta, z) = U + V$ monotonically — then refine the contour with a regularised 1-D $\alpha$-profile in a $\pm 6$-pixel border ribbon.
+
+## Prerequisites
+
+- [[energy-minimization]]
+
+## Sources
+
+- Primary: [[rother2004-grabcut]]
+- Reference: [[boykov2001-graph-cut-segmentation]]

--- a/docs/atlas-vault/algorithms/graph-cut-segmentation.md
+++ b/docs/atlas-vault/algorithms/graph-cut-segmentation.md
@@ -1,0 +1,21 @@
+---
+title: "Graph-Cut Interactive Segmentation"
+type: algorithm
+slug: graph-cut-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/graph-cut-segmentation.md`.
+
+Compute the global minimum of a binary region-and-boundary MRF energy as a single s-t min-cut on a pixel graph; user-marked seeds enter as hard constraints, the output is a binary labelling $A : P \to \{\text{obj}, \text{bkg}\}$ with topology-free segments.
+
+## Prerequisites
+
+- [[energy-minimization]]
+
+## Lineage
+
+- **Extended by** — [[grabcut-iterative-segmentation]]
+
+## Sources
+
+- Primary: [[boykov2001-graph-cut-segmentation]]

--- a/docs/atlas-vault/algorithms/harris-corner-detector.md
+++ b/docs/atlas-vault/algorithms/harris-corner-detector.md
@@ -11,24 +11,16 @@ Scores each pixel by the Harris response R = det(M) − k·tr(M)², where M is t
 ## Prerequisites
 
 - [[image-gradient]]
+- [[non-maximum-suppression]]
 - [[structure-tensor]]
 
-## Related
+## Practice
 
-- [[chess-corners]]
-- [[duda-radon-corners]]
-- [[fast-corner-detector]]
-- [[laureano-topological-chessboard]]
-- [[puzzleboard]]
-- [[pyramidal-blur-aware-xcorner]]
-- [[shi-tomasi-corner-detector]]
-- [[shu-topological-grid]]
-
-## Compared with
-
-- [[chess-corners]]
-- [[fast-corner-detector]]
-- [[shi-tomasi-corner-detector]]
+- **Compared with** — [[chess-corners]]
+- **Compared with** — [[fast-corner-detector]]
+- **Compared with** — [[shi-tomasi-corner-detector]]
+- **Feeds into** — [[orb]] _(confidence: medium)_
+  > Used only as a corner-strength filter to rank FAST keypoints, not as a detector.
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/hartley-projective-rectification.md
+++ b/docs/atlas-vault/algorithms/hartley-projective-rectification.md
@@ -1,0 +1,30 @@
+---
+title: "Hartley Projective Rectification"
+type: algorithm
+slug: hartley-projective-rectification
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/hartley-projective-rectification.md`.
+
+Computes a rectifying homography pair from the fundamental matrix alone, sending the epipole to infinity with a quasi-affine perspectivity and fixing the matching transform by least-squares disparity minimisation.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[homography]]
+- [[stereo-rectification]]
+
+## Lineage
+
+- **Parallel foundation with** — [[loop-zhang-rectification]]
+  > Loop-Zhang minimises rectification distortion explicitly; Hartley minimises disparity.
+
+## Practice
+
+- **Compared with** — [[pollefeys-polar-rectification]]
+  > Hartley's own remedy for an epipole inside the view window is to shrink the window; polar rectification covers that forward-motion case without cropping.
+
+## Sources
+
+- Primary: [[hartley1999-projective-rectification]]
+- Reference: [[longuet-higgins1981-eight-point]]

--- a/docs/atlas-vault/algorithms/hog-descriptor.md
+++ b/docs/atlas-vault/algorithms/hog-descriptor.md
@@ -1,0 +1,26 @@
+---
+title: "HOG: Histograms of Oriented Gradients"
+type: algorithm
+slug: hog-descriptor
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/hog-descriptor.md`.
+
+Compute a fixed-length descriptor for an image window by binning pixel gradients into 8×8 cells of 9 unsigned-orientation histograms, normalising overlapping 2×2-cell blocks with L2-Hys, and concatenating the 3780 block values into a single vector fed to a linear SVM — the canonical pre-CNN pedestrian detector.
+
+## Prerequisites
+
+- [[feature-descriptors]]
+- [[image-gradient]]
+
+## Practice
+
+- **Compared with** — [[viola-jones-detector]] _(confidence: medium)_
+  > Both classical sliding-window detectors. Viola-Jones: Haar + AdaBoost cascade on faces. HOG: gradient histograms + linear SVM on pedestrians.
+- **Feeds into** — [[felzenszwalb-deformable-parts]]
+  > DPM uses HOG cells (k=8 px, α=0.2) with an analytic 31-dim projection of the 36-dim HOG vector as its base feature pyramid.
+
+## Sources
+
+- Primary: [[dalal2005-hog]]
+- Reference: [[lowe2004-sift]]

--- a/docs/atlas-vault/algorithms/horn-schunck.md
+++ b/docs/atlas-vault/algorithms/horn-schunck.md
@@ -1,0 +1,26 @@
+---
+title: "Horn-Schunck Optical Flow"
+type: algorithm
+slug: horn-schunck
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/horn-schunck.md`.
+
+Dense optical flow recovered by minimising a variational energy that combines the brightness-constancy constraint with a global smoothness prior on the velocity field, solved by per-pixel Gauss-Seidel relaxation.
+
+## Prerequisites
+
+- [[image-gradient]]
+- [[optical-flow]]
+
+## Lineage
+
+- **Extended by** — [[black-anandan-robust-flow]]
+  > Robust M-estimator extension of the quadratic data and smoothness terms; non-convex but more tolerant of outliers and motion discontinuities.
+- **Parallel foundation with** — [[lucas-kanade]]
+  > Dense variational vs sparse local LSQ — co-founded optical flow in 1981; pick by problem (dense flow field vs sparse displacement of features).
+
+## Sources
+
+- Primary: [[horn1981-horn-schunck]]
+- Reference: [[lucas1981-lucas-kanade]]

--- a/docs/atlas-vault/algorithms/kumar-generalized-rac.md
+++ b/docs/atlas-vault/algorithms/kumar-generalized-rac.md
@@ -12,10 +12,6 @@ Extend Tsai's radial alignment constraint to a non-frontal sensor by modelling l
 
 - [[camera-distortion-models]]
 
-## Related
-
-- [[zhang-planar-calibration]]
-
 ## Sources
 
 - Primary: [[kumar2014-grac]]

--- a/docs/atlas-vault/algorithms/laureano-topological-chessboard.md
+++ b/docs/atlas-vault/algorithms/laureano-topological-chessboard.md
@@ -14,12 +14,10 @@ Detect every corner of a chessboard calibration pattern and assign it an integer
 - [[image-gradient]]
 - [[topological-grid-recovery]]
 
-## Related
+## Lineage
 
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[fast-corner-detector]]
-- [[shu-topological-grid]]
+- **Alternative formulation of** — [[geiger-chessboard-detector]] _(confidence: medium)_
+  > Less influential in practice than Geiger but methodologically distinct — the X-corner detector is a ring-alternation count rather than a quadrant template, and the topology filter operates on Delaunay triangles directly.
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/lin-sva-stitching.md
+++ b/docs/atlas-vault/algorithms/lin-sva-stitching.md
@@ -11,16 +11,13 @@ Stitch two images under moderate parallax by replacing the global affine with a 
 ## Prerequisites
 
 - [[homography]]
-
-## Related
-
-- [[apap-image-stitching]]
-- [[gao-dual-homography-stitching]]
+- [[ransac]]
 - [[spatially-varying-image-stitching]]
 
-## Compared with
+## Lineage
 
-- [[apap-image-stitching]]
+- **Generalised by** — [[apap-image-stitching]] _(confidence: medium)_
+  > Affine deviation field remains a useful baseline; APAP's projective per-cell grid is more general but not strictly necessary for moderate-parallax planar-scene panoramas.
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/longuet-higgins-eight-point.md
+++ b/docs/atlas-vault/algorithms/longuet-higgins-eight-point.md
@@ -1,0 +1,24 @@
+---
+title: "Longuet-Higgins Linear Eight-Point Algorithm"
+type: algorithm
+slug: longuet-higgins-eight-point
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/longuet-higgins-eight-point.md`.
+
+1981 closed-form linear method for relative orientation of two viewpoints from eight calibrated point correspondences, introducing the bilinear epipolar constraint x'^T Q x = 0 and the matrix Q = R·skew(T) later known as the essential matrix. Superseded for practical use by Hartley's 1997 normalised eight-point algorithm.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[pose-estimation]]
+- [[svd-null-space]]
+
+## Lineage
+
+- **Generalised by** — [[fundamental-matrix-eight-point]]
+
+## Sources
+
+- Primary: [[longuet-higgins1981-eight-point]]
+- Reference: [[hartley1997-eight-point]]

--- a/docs/atlas-vault/algorithms/loop-zhang-rectification.md
+++ b/docs/atlas-vault/algorithms/loop-zhang-rectification.md
@@ -1,0 +1,24 @@
+---
+title: "Loop-Zhang Rectifying Homographies"
+type: algorithm
+slug: loop-zhang-rectification
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/loop-zhang-rectification.md`.
+
+Computes a rectifying homography pair from a known fundamental matrix by factoring each homography as shearing × similarity × projective, choosing the projective component to minimize image distortion.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[homography]]
+- [[stereo-rectification]]
+
+## Practice
+
+- **Compared with** — [[pollefeys-polar-rectification]]
+  > The decomposition still sends the epipole to infinity, so an epipole inside the image forces cropping; polar rectification avoids it.
+
+## Sources
+
+- Primary: [[loop1999-rectifying-homographies]]

--- a/docs/atlas-vault/algorithms/loy-fast-radial-symmetry.md
+++ b/docs/atlas-vault/algorithms/loy-fast-radial-symmetry.md
@@ -1,0 +1,21 @@
+---
+title: "Fast Radial Symmetry Transform"
+type: algorithm
+slug: loy-fast-radial-symmetry
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/loy-fast-radial-symmetry.md`.
+
+Gradient-vote operator that highlights pixels of high local radial symmetry — bright/dark blobs and approximately circular features. Each pixel votes along its gradient direction at one or more radii into orientation and magnitude projection maps; the per-radius contribution is the magnitude projection weighted by a power of the orientation count and Gaussian-smoothed; the cumulative response across radii localises feature centres at $O(K \cdot |N|)$ cost.
+
+## Prerequisites
+
+- [[image-gradient]]
+
+## Lineage
+
+- **Extended by** — [[ni-generalized-fast-radial-symmetry]]
+
+## Sources
+
+- Primary: [[loy2003-frst]]

--- a/docs/atlas-vault/algorithms/lucas-kanade.md
+++ b/docs/atlas-vault/algorithms/lucas-kanade.md
@@ -1,0 +1,27 @@
+---
+title: "Lucas-Kanade Image Registration"
+type: algorithm
+slug: lucas-kanade
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/lucas-kanade.md`.
+
+Iterative Newton-Raphson method that estimates the parametric warp between two images by linearising the residual and solving the resulting weighted normal equation per iteration.
+
+## Prerequisites
+
+- [[image-gradient]]
+- [[optical-flow]]
+- [[structure-tensor]]
+
+## Lineage
+
+- **Extended by** — [[black-anandan-robust-flow]]
+  > Robust M-estimator version of the parametric variant; same machinery as Black-Anandan's piecewise-smooth flow.
+- **Extended by** — [[shi-tomasi-corner-detector]]
+  > Shi-Tomasi derives the feature-selection threshold from the conditioning of the LK normal-equation matrix and adds a 6-DOF affine variant with dissimilarity monitoring.
+
+## Sources
+
+- Primary: [[lucas1981-lucas-kanade]]
+- Reference: [[shi-tomasi1994-features]]

--- a/docs/atlas-vault/algorithms/ni-generalized-fast-radial-symmetry.md
+++ b/docs/atlas-vault/algorithms/ni-generalized-fast-radial-symmetry.md
@@ -1,0 +1,18 @@
+---
+title: "Generalised Fast Radial Symmetry"
+type: algorithm
+slug: ni-generalized-fast-radial-symmetry
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/ni-generalized-fast-radial-symmetry.md`.
+
+Affine extension of FRST: each pixel votes along a corrected direction $\hat V = G M G^{-1} M^{-1} \nabla I$ at radius $n$, where $G = R D \in A(2)$ is a rotation–anisotropic-scale pair from a sampled grid, so circles seen as ellipses under bounded perspective converge into a single peak in the per-pixel-max response stack while keeping FRS's $O(K)$ per-radius cost per $G_i$.
+
+## Prerequisites
+
+- [[image-gradient]]
+
+## Sources
+
+- Primary: [[ni2012-gfrs]]
+- Reference: [[loy2003-frst]]

--- a/docs/atlas-vault/algorithms/ocpad.md
+++ b/docs/atlas-vault/algorithms/ocpad.md
@@ -13,13 +13,6 @@ Recover the largest visible checkerboard subgraph from a partially occluded patt
 - [[image-gradient]]
 - [[topological-grid-recovery]]
 
-## Related
-
-- [[chessboard-x-corner-detection]]
-- [[laureano-topological-chessboard]]
-- [[puzzleboard]]
-- [[shu-topological-grid]]
-
 ## Sources
 
 - Primary: [[fuersattel2016-ocpad]]

--- a/docs/atlas-vault/algorithms/orb.md
+++ b/docs/atlas-vault/algorithms/orb.md
@@ -1,0 +1,27 @@
+---
+title: "ORB: Oriented FAST and Rotated BRIEF"
+type: algorithm
+slug: orb
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/orb.md`.
+
+Detects rotation-invariant oriented keypoints by running FAST-9 on a √2 image pyramid, ranking by Harris cornerness, and assigning orientation from the intensity centroid; describes each keypoint with a 256-bit rBRIEF binary string formed by greedy selection of low-correlation, high-variance pairwise pixel-intensity tests on a smoothed 31×31 patch.
+
+## Prerequisites
+
+- [[feature-descriptors]]
+- [[image-gradient]]
+- [[image-pyramid]]
+- [[integral-image]]
+- [[scale-space]]
+
+## Sources
+
+- Primary: [[rublee2011-orb]]
+- Reference: [[bay2006-surf]]
+- Reference: [[calonder2010-brief]]
+- Reference: [[harris1988-corner]]
+- Reference: [[lowe2004-sift]]
+- Reference: [[rosten2006-fast]]
+- Reference: [[viola2001-detector]]

--- a/docs/atlas-vault/algorithms/pollefeys-polar-rectification.md
+++ b/docs/atlas-vault/algorithms/pollefeys-polar-rectification.md
@@ -1,0 +1,19 @@
+---
+title: "Pollefeys Polar Rectification"
+type: algorithm
+slug: pollefeys-polar-rectification
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/pollefeys-polar-rectification.md`.
+
+Rectification by polar reparametrisation around the epipole, requiring only the oriented fundamental matrix and remaining bounded even when the epipole lies inside the image.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[stereo-rectification]]
+
+## Sources
+
+- Primary: [[pollefeys1999-polar-rectification]]
+- Reference: [[longuet-higgins1981-eight-point]]

--- a/docs/atlas-vault/algorithms/puzzleboard.md
+++ b/docs/atlas-vault/algorithms/puzzleboard.md
@@ -14,13 +14,6 @@ Detect and decode a self-identifying checkerboard calibration pattern: saddle-po
 - [[image-gradient]]
 - [[topological-grid-recovery]]
 
-## Related
-
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[harris-corner-detector]]
-- [[shu-topological-grid]]
-
 ## Sources
 
 - Primary: [[stelldinger2024-puzzleboard]]

--- a/docs/atlas-vault/algorithms/pyramidal-blur-aware-xcorner.md
+++ b/docs/atlas-vault/algorithms/pyramidal-blur-aware-xcorner.md
@@ -11,15 +11,8 @@ Detect chessboard X-junctions in heavily blurred or high-resolution images by co
 ## Prerequisites
 
 - [[image-gradient]]
+- [[image-pyramid]]
 - [[scale-space]]
-
-## Related
-
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[rochade]]
-- [[shi-tomasi-corner-detector]]
-- [[shu-topological-grid]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/raguram-usac.md
+++ b/docs/atlas-vault/algorithms/raguram-usac.md
@@ -1,0 +1,21 @@
+---
+title: "USAC: Universal RANSAC Framework"
+type: algorithm
+slug: raguram-usac
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/raguram-usac.md`.
+
+Engineering decomposition of practical RANSAC into four pluggable stages — sampling (PROSAC), model verification (SPRT), local optimisation (LO-RANSAC), and degeneracy handling (DEGENSAC) — with a single reference C++ implementation (USAC-1.0) and an SPRT-corrected stopping criterion.
+
+## Prerequisites
+
+- [[ransac]]
+
+## Practice
+
+- **Compared with** — [[barath-magsac]]
+
+## Sources
+
+- Primary: [[raguram2013-usac]]

--- a/docs/atlas-vault/algorithms/rochade.md
+++ b/docs/atlas-vault/algorithms/rochade.md
@@ -13,17 +13,9 @@ Detect a full planar checkerboard in an image by reducing the gradient-magnitude
 - [[hessian-saddle-response]]
 - [[image-gradient]]
 
-## Related
+## Practice
 
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[laureano-topological-chessboard]]
-- [[ocpad]]
-- [[shu-topological-grid]]
-
-## Compared with
-
-- [[pyramidal-blur-aware-xcorner]]
+- **Compared with** — [[pyramidal-blur-aware-xcorner]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/scaramuzza-omni-calibration.md
+++ b/docs/atlas-vault/algorithms/scaramuzza-omni-calibration.md
@@ -1,0 +1,21 @@
+---
+title: "Scaramuzza Omnidirectional Camera Calibration"
+type: algorithm
+slug: scaramuzza-omni-calibration
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/scaramuzza-omni-calibration.md`.
+
+Calibrate any central catadioptric or fisheye camera from a few planar checkerboard views by fitting a radially-symmetric Taylor-polynomial imaging function with a linear estimate followed by maximum-likelihood refinement.
+
+## Prerequisites
+
+- [[bundle-adjustment]]
+- [[camera-distortion-models]]
+- [[pinhole-camera-model]]
+
+## Sources
+
+- Primary: [[scaramuzza2006-omni]]
+- Reference: [[rufli2008-blurred]]
+- Reference: [[zhang2000-flexible]]

--- a/docs/atlas-vault/algorithms/shi-tomasi-corner-detector.md
+++ b/docs/atlas-vault/algorithms/shi-tomasi-corner-detector.md
@@ -11,13 +11,8 @@ Scores each pixel by the smaller eigenvalue of the gradient structure tensor M; 
 ## Prerequisites
 
 - [[image-gradient]]
+- [[non-maximum-suppression]]
 - [[structure-tensor]]
-
-## Related
-
-- [[chess-corners]]
-- [[fast-corner-detector]]
-- [[harris-corner-detector]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/shu-topological-grid.md
+++ b/docs/atlas-vault/algorithms/shu-topological-grid.md
@@ -13,16 +13,14 @@ Recover the integer $(i, j)$ grid coordinate of every corner in a checkerboard c
 - [[image-gradient]]
 - [[topological-grid-recovery]]
 
-## Related
+## Lineage
 
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[harris-corner-detector]]
-- [[shi-tomasi-corner-detector]]
+- **Alternative formulation of** — [[geiger-chessboard-detector]] _(confidence: medium)_
+  > Different abstraction layer — topological grid recovery from a candidate corner set vs single-shot detection that integrates corner finding and grid linking. Not superseded by Geiger; both remain in practitioner use.
 
-## Compared with
+## Practice
 
-- [[laureano-topological-chessboard]]
+- **Compared with** — [[laureano-topological-chessboard]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/sift.md
+++ b/docs/atlas-vault/algorithms/sift.md
@@ -1,0 +1,29 @@
+---
+title: "SIFT: Scale-Invariant Feature Transform"
+type: algorithm
+slug: sift
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/sift.md`.
+
+Detects keypoints as scale-space extrema in a Difference-of-Gaussian image pyramid, refines location and scale by 3D quadratic interpolation, assigns canonical orientation from local gradient histograms, and emits a 128-D descriptor invariant to scale, rotation, and moderate affine and illumination change.
+
+## Prerequisites
+
+- [[feature-descriptors]]
+- [[feature-matching]]
+- [[image-gradient]]
+- [[image-pyramid]]
+- [[scale-space]]
+
+## Practice
+
+- **Compared with** — [[fast-corner-detector]]
+- **Compared with** — [[harris-corner-detector]]
+- **Compared with** — [[orb]]
+- **Compared with** — [[shi-tomasi-corner-detector]]
+
+## Sources
+
+- Primary: [[lowe2004-sift]]
+- Reference: [[harris1988-corner]]

--- a/docs/atlas-vault/algorithms/sturm-plane-based-calibration.md
+++ b/docs/atlas-vault/algorithms/sturm-plane-based-calibration.md
@@ -11,10 +11,7 @@ Recover camera intrinsics from one or more views of one or more planar targets v
 ## Prerequisites
 
 - [[homography]]
-
-## Related
-
-- [[zhang-planar-calibration]]
+- [[pinhole-camera-model]]
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/surf.md
+++ b/docs/atlas-vault/algorithms/surf.md
@@ -1,0 +1,35 @@
+---
+title: "SURF: Speeded Up Robust Features"
+type: algorithm
+slug: surf
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/surf.md`.
+
+Detects scale- and rotation-invariant blob keypoints as scale-space maxima of the Hessian determinant, approximated with box filters on an integral image, and emits a 64-D Haar-wavelet response descriptor matched by Euclidean distance with a Laplacian-sign pre-filter.
+
+## Prerequisites
+
+- [[image-gradient]]
+- [[image-pyramid]]
+- [[integral-image]]
+- [[scale-space]]
+
+## Lineage
+
+- **Alternative formulation of** — [[sift]]
+
+## Practice
+
+- **Compared with** — [[fast-corner-detector]] _(confidence: medium)_
+  > FAST is detector-only; SURF bundles a descriptor.
+- **Compared with** — [[harris-corner-detector]] _(confidence: medium)_
+- **Compared with** — [[orb]]
+- **Compared with** — [[shi-tomasi-corner-detector]] _(confidence: medium)_
+
+## Sources
+
+- Primary: [[bay2006-surf]]
+- Reference: [[harris1988-corner]]
+- Reference: [[lowe2004-sift]]
+- Reference: [[viola2001-detector]]

--- a/docs/atlas-vault/algorithms/tsai-lenz-handeye.md
+++ b/docs/atlas-vault/algorithms/tsai-lenz-handeye.md
@@ -8,14 +8,10 @@ slug: tsai-lenz-handeye
 
 Recover the constant rigid transform from a robot gripper to a rigidly mounted camera by solving the AX=XB equation in two stages — modified Rodrigues rotation, then translation.
 
-## Related
+## Lineage
 
-- [[daniilidis-dual-quaternion-handeye]]
-- [[zhang-planar-calibration]]
-
-## Compared with
-
-- [[daniilidis-dual-quaternion-handeye]]
+- **Alternative formulation of** — [[daniilidis-dual-quaternion-handeye]]
+  > Daniilidis's dual-quaternion solver couples rotation and translation simultaneously; both methods remain in practitioner use.
 
 ## Sources
 

--- a/docs/atlas-vault/algorithms/tsai-versatile-calibration.md
+++ b/docs/atlas-vault/algorithms/tsai-versatile-calibration.md
@@ -6,27 +6,26 @@ slug: tsai-versatile-calibration
 
 > Generated stub — do not edit. Source: `content/algorithms/tsai-versatile-calibration.md`.
 
-Two-stage camera calibration that uses the radial alignment constraint to recover extrinsics and image scale linearly from a 3D calibration target, then refines focal length, depth translation, and one radial-distortion coefficient by a short nonlinear solve over three unknowns.
+Two-stage 1987 camera calibration that uses the radial alignment constraint to recover extrinsics and image scale linearly from a precision 3D calibration target, then refines focal length, depth translation, and one radial-distortion coefficient by a short nonlinear solve over three unknowns. Superseded for practical use by Zhang's planar method.
 
 ## Prerequisites
 
+- [[bundle-adjustment]]
 - [[camera-distortion-models]]
+- [[pinhole-camera-model]]
 
-## Related
+## Lineage
 
-- [[kumar-generalized-rac]]
-- [[tsai-lenz-handeye]]
-- [[zhang-planar-calibration]]
+- **Generalised by** — [[zhang-planar-calibration]]
 
-## Compared with
+## Practice
 
-- [[kumar-generalized-rac]]
-- [[zhang-planar-calibration]]
+- **Feeds into** — [[tsai-lenz-handeye]]
+  > Tsai 1987's per-station extrinsics are the canonical input format for the Tsai-Lenz hand-eye AX = XB solver.
 
 ## Sources
 
 - Primary: [[tsai1987-versatile]]
 - Reference: [[daniilidis1999-hand-eye]]
-- Reference: [[kumar2014-grac]]
 - Reference: [[weng1992-camera]]
 - Reference: [[zhang2000-flexible]]

--- a/docs/atlas-vault/algorithms/viola-jones-detector.md
+++ b/docs/atlas-vault/algorithms/viola-jones-detector.md
@@ -1,0 +1,17 @@
+---
+title: "Viola–Jones Object Detector"
+type: algorithm
+slug: viola-jones-detector
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/viola-jones-detector.md`.
+
+Real-time frontal-face detection by sliding a fixed 24×24 sub-window across a grayscale image at multiple scales, scoring each position with an AdaBoost-selected ensemble of integral-image rectangle features arranged in a 38-stage attentional cascade that rejects most background regions after evaluating ~10 features per sub-window.
+
+## Prerequisites
+
+- [[integral-image]]
+
+## Sources
+
+- Primary: [[viola2001-detector]]

--- a/docs/atlas-vault/algorithms/yang-sub-pixel-corner-fit.md
+++ b/docs/atlas-vault/algorithms/yang-sub-pixel-corner-fit.md
@@ -1,0 +1,30 @@
+---
+title: "Yang Parametric-Model Sub-Pixel Corner Fit"
+type: algorithm
+slug: yang-sub-pixel-corner-fit
+---
+
+> Generated stub — do not edit. Source: `content/algorithms/yang-sub-pixel-corner-fit.md`.
+
+Refine pixel-level chessboard corner positions to sub-pixel accuracy by nonlinear least-squares fitting a seven-parameter ideal blurred-corner model directly to the raw image patch, then reject unreliable corners via a boxplot-based fit-quality self-check before passing to PnP.
+
+## Prerequisites
+
+- [[image-gradient]]
+
+## Practice
+
+- **Compared with** — [[duda-radon-corners]] _(confidence: medium)_
+- **Compared with** — [[geiger-chessboard-detector]]
+- **Compared with** — [[pyramidal-blur-aware-xcorner]] _(confidence: medium)_
+  > Pyramidal builds on ROCHADE; yang2018 fits a parametric saddle model — different mechanism
+- **Compared with** — [[rochade]]
+
+## Sources
+
+- Primary: [[yang2018-sub-pixel]]
+- Reference: [[chen2005-xcorner]]
+- Reference: [[harris1988-corner]]
+- Reference: [[lepetit2009-epnp]]
+- Reference: [[placht2014-rochade]]
+- Reference: [[zhang2000-flexible]]

--- a/docs/atlas-vault/algorithms/zhang-planar-calibration.md
+++ b/docs/atlas-vault/algorithms/zhang-planar-calibration.md
@@ -10,18 +10,16 @@ Recover camera intrinsics, radial distortion, and per-view extrinsics from at le
 
 ## Prerequisites
 
+- [[bundle-adjustment]]
 - [[camera-distortion-models]]
 - [[homography]]
+- [[pinhole-camera-model]]
+- [[ransac]]
 
-## Related
+## Lineage
 
-- [[chess-corners]]
-- [[puzzleboard]]
-- [[rochade]]
-
-## Compared with
-
-- [[sturm-plane-based-calibration]]
+- **Parallel foundation with** — [[sturm-plane-based-calibration]]
+  > Zhang became the practical industry standard; Sturm-Maybank remains theoretically broader on singularity analysis.
 
 ## Sources
 
@@ -29,3 +27,4 @@ Recover camera intrinsics, radial distortion, and per-view extrinsics from at le
 - Reference: [[sturm2003-plane-based]]
 - Reference: [[tsai1987-versatile]]
 - Reference: [[weng1992-camera]]
+- Reference: [[zhang2022-learning-based]]

--- a/docs/atlas-vault/concepts/attention-mechanism.md
+++ b/docs/atlas-vault/concepts/attention-mechanism.md
@@ -1,0 +1,15 @@
+---
+title: "Attention Mechanism"
+type: concept
+slug: attention-mechanism
+---
+
+> Generated stub — do not edit. Source: `content/concepts/attention-mechanism.md`.
+
+Computes each output element as a learned, input-dependent weighted average of value vectors, letting every element aggregate information from any other regardless of distance.
+
+## Sources
+
+- Primary: [[sarlin2020-superglue]]
+- Reference: [[lindenberger2023-lightglue]]
+- Reference: [[sun2021-loftr]]

--- a/docs/atlas-vault/concepts/bundle-adjustment.md
+++ b/docs/atlas-vault/concepts/bundle-adjustment.md
@@ -1,0 +1,19 @@
+---
+title: "Bundle Adjustment"
+type: concept
+slug: bundle-adjustment
+---
+
+> Generated stub — do not edit. Source: `content/concepts/bundle-adjustment.md`.
+
+Joint nonlinear least-squares refinement of all camera parameters — and, in structure-from-motion, all 3-D points — that minimises the total reprojection error.
+
+## Prerequisites
+
+- [[pinhole-camera-model]]
+
+## Sources
+
+- Primary: [[zhang2000-flexible]]
+- Reference: [[tsai1987-versatile]]
+- Reference: [[weng1992-camera]]

--- a/docs/atlas-vault/concepts/camera-distortion-models.md
+++ b/docs/atlas-vault/concepts/camera-distortion-models.md
@@ -8,11 +8,9 @@ slug: camera-distortion-models
 
 Mathematical models for departures from the ideal pinhole projection — radial barrel/pincushion, tangential decentering, thin-prism — and the historical lineage from Brown's photogrammetric polynomial through Tsai's one-term radial, Weng's full Brown-Conrady, and Zhang's two-term planar formulation.
 
-## Related
+## Prerequisites
 
-- [[kumar-generalized-rac]]
-- [[tsai-versatile-calibration]]
-- [[zhang-planar-calibration]]
+- [[pinhole-camera-model]]
 
 ## Sources
 
@@ -20,3 +18,4 @@ Mathematical models for departures from the ideal pinhole projection — radial 
 - Reference: [[tsai1987-versatile]]
 - Reference: [[weng1992-camera]]
 - Reference: [[zhang2000-flexible]]
+- Reference: [[zhang2022-learning-based]]

--- a/docs/atlas-vault/concepts/chessboard-x-corner-detection.md
+++ b/docs/atlas-vault/concepts/chessboard-x-corner-detection.md
@@ -6,28 +6,11 @@ slug: chessboard-x-corner-detection
 
 > Generated stub — do not edit. Source: `content/concepts/chessboard-x-corner-detection.md`.
 
-Twenty-five years of methods for finding the inner corners of a planar checkerboard calibration target — from Harris-on-thresholded-images through hand-crafted ring/quadrant/Hessian responses (ChESS, Geiger, Shu, Laureano, ROCHADE) to learned per-pixel CNNs (MATE, CCDN), grouped by the four design axes that drive the trade-off: per-pixel response operator, multi-scale strategy, structure recovery, and subpixel refinement.
+Twenty-five years of methods for finding the inner corners of a planar checkerboard calibration target — from Harris-on-thresholded-images through hand-crafted ring/quadrant/Hessian responses (ChESS, Geiger, Shu, Laureano, ROCHADE) to learned per-pixel CNNs (MATE, CCDN) and learned heatmap pipelines (CCS), grouped by the four design axes that drive the trade-off: per-pixel response operator, multi-scale strategy, structure recovery, and subpixel refinement.
 
 ## Prerequisites
 
 - [[image-gradient]]
-
-## Related
-
-- [[ccdn-checkerboard-detector]]
-- [[chess-corners]]
-- [[duda-radon-corners]]
-- [[geiger-chessboard-detector]]
-- [[gp-checkerboard-enhancement]]
-- [[hessian-saddle-response]]
-- [[laureano-topological-chessboard]]
-- [[mate-checkerboard-detector]]
-- [[ocpad]]
-- [[puzzleboard]]
-- [[pyramidal-blur-aware-xcorner]]
-- [[rochade]]
-- [[shu-topological-grid]]
-- [[topological-grid-recovery]]
 
 ## Sources
 
@@ -43,3 +26,5 @@ Twenty-five years of methods for finding the inner corners of a planar checkerbo
 - Reference: [[placht2014-rochade]]
 - Reference: [[shu2009-topological]]
 - Reference: [[stelldinger2024-puzzleboard]]
+- Reference: [[yang2018-sub-pixel]]
+- Reference: [[zhang2022-learning-based]]

--- a/docs/atlas-vault/concepts/convolution.md
+++ b/docs/atlas-vault/concepts/convolution.md
@@ -1,0 +1,15 @@
+---
+title: "Convolution"
+type: concept
+slug: convolution
+---
+
+> Generated stub — do not edit. Source: `content/concepts/convolution.md`.
+
+The linear, shift-invariant operation that produces each output pixel as a kernel-weighted sum of input pixels in a local neighbourhood.
+
+## Sources
+
+- Primary: [[canny1986-edge]]
+- Reference: [[krizhevsky2012-alexnet]]
+- Reference: [[simonyan2014-vgg]]

--- a/docs/atlas-vault/concepts/convolutional-neural-network.md
+++ b/docs/atlas-vault/concepts/convolutional-neural-network.md
@@ -1,0 +1,20 @@
+---
+title: "Convolutional Neural Network"
+type: concept
+slug: convolutional-neural-network
+---
+
+> Generated stub — do not edit. Source: `content/concepts/convolutional-neural-network.md`.
+
+A feed-forward network that builds a spatial hierarchy of learned features by alternating weight-shared convolution layers, pointwise nonlinearities, and spatial downsampling, trained end-to-end by backpropagation.
+
+## Prerequisites
+
+- [[convolution]]
+
+## Sources
+
+- Primary: [[krizhevsky2012-alexnet]]
+- Reference: [[he2016-resnet]]
+- Reference: [[simonyan2014-vgg]]
+- Reference: [[szegedy2015-inception]]

--- a/docs/atlas-vault/concepts/dlt-normalisation.md
+++ b/docs/atlas-vault/concepts/dlt-normalisation.md
@@ -8,12 +8,10 @@ slug: dlt-normalisation
 
 A two-line similarity transform — translate the point centroid to the origin, isotropically scale so the average distance is √2 — that conditions the design matrix of any DLT-based estimator (homography, fundamental matrix, projective camera, Moving DLT) by ~10⁸, and is the difference between unusable and reliable linear solutions.
 
-## Related
+## Prerequisites
 
-- [[apap-image-stitching]]
-- [[epipolar-geometry]]
-- [[fundamental-matrix-eight-point]]
-- [[homography]]
+- [[ransac]]
+- [[svd-null-space]]
 
 ## Sources
 

--- a/docs/atlas-vault/concepts/energy-minimization.md
+++ b/docs/atlas-vault/concepts/energy-minimization.md
@@ -1,0 +1,15 @@
+---
+title: "Energy Minimization"
+type: concept
+slug: energy-minimization
+---
+
+> Generated stub — do not edit. Source: `content/concepts/energy-minimization.md`.
+
+The framework that poses image labelling and segmentation as minimising an objective combining a per-pixel data term and a pairwise smoothness term over a graph of pixels.
+
+## Sources
+
+- Primary: [[boykov2001-graph-cut-segmentation]]
+- Reference: [[felzenszwalb2004-graph-segm]]
+- Reference: [[rother2004-grabcut]]

--- a/docs/atlas-vault/concepts/epipolar-geometry.md
+++ b/docs/atlas-vault/concepts/epipolar-geometry.md
@@ -8,9 +8,12 @@ slug: epipolar-geometry
 
 The intrinsic projective geometry of two views of a scene, encoding the constraint that a point visible in one image must lie on a specific line in the other image determined entirely by the camera positions.
 
-## Related
+## Prerequisites
 
-- [[dlt-normalisation]]
+- [[homography]]
+- [[pinhole-camera-model]]
+- [[ransac]]
+- [[svd-null-space]]
 
 ## Sources
 

--- a/docs/atlas-vault/concepts/feature-descriptors.md
+++ b/docs/atlas-vault/concepts/feature-descriptors.md
@@ -1,0 +1,20 @@
+---
+title: "Feature Descriptors"
+type: concept
+slug: feature-descriptors
+---
+
+> Generated stub — do not edit. Source: `content/concepts/feature-descriptors.md`.
+
+Fixed-length vectors encoding the local image appearance around a keypoint, built so the same physical point yields similar descriptors across views — the basis for descriptor matching.
+
+## Prerequisites
+
+- [[image-gradient]]
+
+## Sources
+
+- Primary: [[lowe2004-sift]]
+- Reference: [[calonder2010-brief]]
+- Reference: [[dalal2005-hog]]
+- Reference: [[rublee2011-orb]]

--- a/docs/atlas-vault/concepts/feature-matching.md
+++ b/docs/atlas-vault/concepts/feature-matching.md
@@ -1,0 +1,22 @@
+---
+title: "Feature Matching"
+type: concept
+slug: feature-matching
+---
+
+> Generated stub — do not edit. Source: `content/concepts/feature-matching.md`.
+
+Establishing keypoint correspondences between two images by comparing descriptors and resolving them into a consistent partial assignment — from the ratio test to learned optimal-transport matchers.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[feature-descriptors]]
+
+## Sources
+
+- Primary: [[lowe2004-sift]]
+- Reference: [[detone2018-superpoint]]
+- Reference: [[lindenberger2023-lightglue]]
+- Reference: [[sarlin2020-superglue]]
+- Reference: [[sun2021-loftr]]

--- a/docs/atlas-vault/concepts/feed-forward-3d-reconstruction.md
+++ b/docs/atlas-vault/concepts/feed-forward-3d-reconstruction.md
@@ -1,0 +1,23 @@
+---
+title: "Feed-Forward 3D Reconstruction"
+type: concept
+slug: feed-forward-3d-reconstruction
+---
+
+> Generated stub — do not edit. Source: `content/concepts/feed-forward-3d-reconstruction.md`.
+
+Recovering 3D geometry — point maps, depth, and camera poses — directly from images in a single network pass, replacing the detect-match-triangulate-bundle-adjust pipeline of classical structure-from-motion with learned pointmap regression.
+
+## Prerequisites
+
+- [[bundle-adjustment]]
+- [[epipolar-geometry]]
+- [[pinhole-camera-model]]
+- [[pose-estimation]]
+
+## Sources
+
+- Primary: [[wang2023-dust3r]]
+- Reference: [[leroy2024-mast3r]]
+- Reference: [[lin2025-depth-anything-3]]
+- Reference: [[wang2025-vggt]]

--- a/docs/atlas-vault/concepts/hessian-saddle-response.md
+++ b/docs/atlas-vault/concepts/hessian-saddle-response.md
@@ -12,14 +12,6 @@ A scalar response computed from the determinant of the image Hessian, negative a
 
 - [[image-gradient]]
 
-## Related
-
-- [[chess-corners]]
-- [[laureano-topological-chessboard]]
-- [[puzzleboard]]
-- [[rochade]]
-- [[structure-tensor]]
-
 ## Sources
 
 - Reference: [[chen2005-xcorner]]

--- a/docs/atlas-vault/concepts/homography.md
+++ b/docs/atlas-vault/concepts/homography.md
@@ -8,11 +8,10 @@ slug: homography
 
 An invertible projective transformation of the plane, represented by a 3×3 matrix defined up to a non-zero scalar, mapping points between two images of a planar surface or capturing a pure camera rotation.
 
-## Related
+## Prerequisites
 
-- [[apap-image-stitching]]
-- [[dlt-normalisation]]
-- [[zhang-planar-calibration]]
+- [[ransac]]
+- [[svd-null-space]]
 
 ## Sources
 

--- a/docs/atlas-vault/concepts/image-gradient.md
+++ b/docs/atlas-vault/concepts/image-gradient.md
@@ -8,10 +8,6 @@ slug: image-gradient
 
 The 2-vector of partial derivatives of image intensity with respect to spatial coordinates, measuring the rate and direction of brightness change at each pixel.
 
-## Related
+## Prerequisites
 
-- [[chess-corners]]
-- [[fast-corner-detector]]
-- [[harris-corner-detector]]
-- [[pyramidal-blur-aware-xcorner]]
-- [[shi-tomasi-corner-detector]]
+- [[convolution]]

--- a/docs/atlas-vault/concepts/image-pyramid.md
+++ b/docs/atlas-vault/concepts/image-pyramid.md
@@ -1,0 +1,15 @@
+---
+title: "Image Pyramid"
+type: concept
+slug: image-pyramid
+---
+
+> Generated stub — do not edit. Source: `content/concepts/image-pyramid.md`.
+
+A discrete multi-resolution representation — a sequence of images at progressively coarser resolution, each smoothed and downsampled from its predecessor.
+
+## Sources
+
+- Primary: [[lowe2004-sift]]
+- Reference: [[abeles2021-pyramidal]]
+- Reference: [[bay2006-surf]]

--- a/docs/atlas-vault/concepts/integral-image.md
+++ b/docs/atlas-vault/concepts/integral-image.md
@@ -1,0 +1,17 @@
+---
+title: "Integral Image"
+type: concept
+slug: integral-image
+---
+
+> Generated stub — do not edit. Source: `content/concepts/integral-image.md`.
+
+A precomputed prefix-sum array that returns the sum of pixel values over any axis-aligned rectangle in constant time with four array reads.
+
+## Sources
+
+- Primary: [[crow1984-summed-area]]
+- Reference: [[bay2006-surf]]
+- Reference: [[calonder2010-brief]]
+- Reference: [[rublee2011-orb]]
+- Reference: [[viola2001-detector]]

--- a/docs/atlas-vault/concepts/monocular-depth-estimation.md
+++ b/docs/atlas-vault/concepts/monocular-depth-estimation.md
@@ -1,0 +1,20 @@
+---
+title: "Monocular Depth Estimation"
+type: concept
+slug: monocular-depth-estimation
+---
+
+> Generated stub — do not edit. Source: `content/concepts/monocular-depth-estimation.md`.
+
+Predicting per-pixel scene depth from a single image — the scale ambiguity that forces relative (affine-invariant) versus metric formulations, the scale-and-shift-invariant training that lets incompatible datasets be mixed, and the foundation-model recipe that scaled it to zero-shot generalization.
+
+## Prerequisites
+
+- [[pinhole-camera-model]]
+
+## Sources
+
+- Primary: [[ranftl2019-midas]]
+- Reference: [[lin2025-depth-anything-3]]
+- Reference: [[yang2024-depth-anything]]
+- Reference: [[yang2024-depth-anything-v2]]

--- a/docs/atlas-vault/concepts/non-maximum-suppression.md
+++ b/docs/atlas-vault/concepts/non-maximum-suppression.md
@@ -1,0 +1,17 @@
+---
+title: "Non-Maximum Suppression"
+type: concept
+slug: non-maximum-suppression
+---
+
+> Generated stub — do not edit. Source: `content/concepts/non-maximum-suppression.md`.
+
+Reducing a dense response map or a set of overlapping detections to a sparse set of local maxima by discarding every element that is not strongest in its neighbourhood.
+
+## Sources
+
+- Primary: [[canny1986-edge]]
+- Reference: [[harris1988-corner]]
+- Reference: [[redmon2016-yolo]]
+- Reference: [[rosten2006-fast]]
+- Reference: [[shi-tomasi1994-features]]

--- a/docs/atlas-vault/concepts/optical-flow.md
+++ b/docs/atlas-vault/concepts/optical-flow.md
@@ -1,0 +1,21 @@
+---
+title: "Optical Flow"
+type: concept
+slug: optical-flow
+---
+
+> Generated stub — do not edit. Source: `content/concepts/optical-flow.md`.
+
+The apparent 2-D velocity field of image brightness between consecutive frames, recovered from the spatio-temporal gradient under the brightness-constancy assumption.
+
+## Prerequisites
+
+- [[image-gradient]]
+- [[structure-tensor]]
+
+## Sources
+
+- Primary: [[horn1981-horn-schunck]]
+- Reference: [[black1996-robust]]
+- Reference: [[lucas1981-lucas-kanade]]
+- Reference: [[tomasi1991-detection-tracking]]

--- a/docs/atlas-vault/concepts/pinhole-camera-model.md
+++ b/docs/atlas-vault/concepts/pinhole-camera-model.md
@@ -1,0 +1,16 @@
+---
+title: "Pinhole Camera Model"
+type: concept
+slug: pinhole-camera-model
+---
+
+> Generated stub — do not edit. Source: `content/concepts/pinhole-camera-model.md`.
+
+The projective map from 3-D scene points to 2-D image pixels through a single centre of projection, parameterised by an intrinsic matrix and an extrinsic pose.
+
+## Sources
+
+- Primary: [[zhang2000-flexible]]
+- Reference: [[sturm2003-plane-based]]
+- Reference: [[tsai1987-versatile]]
+- Reference: [[weng1992-camera]]

--- a/docs/atlas-vault/concepts/pose-estimation.md
+++ b/docs/atlas-vault/concepts/pose-estimation.md
@@ -1,0 +1,19 @@
+---
+title: "Pose Estimation"
+type: concept
+slug: pose-estimation
+---
+
+> Generated stub — do not edit. Source: `content/concepts/pose-estimation.md`.
+
+Recovery of the 6-DOF rigid transformation — rotation and translation — relating a camera to a scene, an object, or a second camera.
+
+## Prerequisites
+
+- [[pinhole-camera-model]]
+
+## Sources
+
+- Primary: [[lepetit2009-epnp]]
+- Reference: [[longuet-higgins1981-eight-point]]
+- Reference: [[zhang2000-flexible]]

--- a/docs/atlas-vault/concepts/ransac.md
+++ b/docs/atlas-vault/concepts/ransac.md
@@ -1,0 +1,15 @@
+---
+title: "RANSAC"
+type: concept
+slug: ransac
+---
+
+> Generated stub — do not edit. Source: `content/concepts/ransac.md`.
+
+Random sample consensus — a paradigm for fitting a parametric model to data containing an unknown fraction of gross outliers, by drawing minimal random subsets, instantiating candidate models, and selecting the one with the largest globally consistent inlier set.
+
+## Sources
+
+- Reference: [[barath2019-magsac]]
+- Reference: [[fischler1981-ransac]]
+- Reference: [[raguram2013-usac]]

--- a/docs/atlas-vault/concepts/scale-space.md
+++ b/docs/atlas-vault/concepts/scale-space.md
@@ -8,7 +8,6 @@ slug: scale-space
 
 A one-parameter family of images obtained by progressively blurring an input image with Gaussians of increasing standard deviation, providing a principled multi-scale representation for detecting and describing image features.
 
-## Related
+## Prerequisites
 
-- [[chess-corners]]
-- [[pyramidal-blur-aware-xcorner]]
+- [[convolution]]

--- a/docs/atlas-vault/concepts/spatially-varying-image-stitching.md
+++ b/docs/atlas-vault/concepts/spatially-varying-image-stitching.md
@@ -11,13 +11,7 @@ A 2011–2013 lineage of stitching methods that replace the single global homogr
 ## Prerequisites
 
 - [[homography]]
-
-## Related
-
-- [[apap-image-stitching]]
-- [[dlt-normalisation]]
-- [[gao-dual-homography-stitching]]
-- [[lin-sva-stitching]]
+- [[ransac]]
 
 ## Sources
 

--- a/docs/atlas-vault/concepts/stereo-rectification.md
+++ b/docs/atlas-vault/concepts/stereo-rectification.md
@@ -1,0 +1,24 @@
+---
+title: "Stereo Rectification"
+type: concept
+slug: stereo-rectification
+---
+
+> Generated stub — do not edit. Source: `content/concepts/stereo-rectification.md`.
+
+Warping a stereo pair so corresponding epipolar lines become collinear image rows, reducing dense correspondence to a scanline search; calibrated Euclidean methods and uncalibrated projective methods solve the same problem under different input assumptions.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[homography]]
+- [[pinhole-camera-model]]
+- [[pose-estimation]]
+
+## Sources
+
+- Reference: [[fusiello2000-compact-rectification]]
+- Reference: [[hartley1997-eight-point]]
+- Reference: [[hartley1999-projective-rectification]]
+- Reference: [[loop1999-rectifying-homographies]]
+- Reference: [[pollefeys1999-polar-rectification]]

--- a/docs/atlas-vault/concepts/structure-tensor.md
+++ b/docs/atlas-vault/concepts/structure-tensor.md
@@ -11,8 +11,3 @@ A symmetric 2×2 matrix formed by summing the outer products of the image gradie
 ## Prerequisites
 
 - [[image-gradient]]
-
-## Related
-
-- [[harris-corner-detector]]
-- [[shi-tomasi-corner-detector]]

--- a/docs/atlas-vault/concepts/svd-null-space.md
+++ b/docs/atlas-vault/concepts/svd-null-space.md
@@ -1,0 +1,16 @@
+---
+title: "SVD Null-Space Estimation"
+type: concept
+slug: svd-null-space
+---
+
+> Generated stub — do not edit. Source: `content/concepts/svd-null-space.md`.
+
+Estimating a geometric entity defined only up to scale by stacking constraints into a homogeneous linear system and taking the smallest right-singular vector of the design matrix.
+
+## Sources
+
+- Primary: [[longuet-higgins1981-eight-point]]
+- Reference: [[gao2011-dual-homography]]
+- Reference: [[hartley1997-eight-point]]
+- Reference: [[zhang2000-flexible]]

--- a/docs/atlas-vault/concepts/topological-grid-recovery.md
+++ b/docs/atlas-vault/concepts/topological-grid-recovery.md
@@ -8,13 +8,6 @@ slug: topological-grid-recovery
 
 Verify candidate calibration-pattern corners by constructing a graph over them (Delaunay triangulation, k-nearest-neighbours, or proximity) and accepting only configurations that match the expected chessboard topology — false positives are eliminated by structural rules rather than per-pixel response thresholds.
 
-## Related
-
-- [[laureano-topological-chessboard]]
-- [[ocpad]]
-- [[puzzleboard]]
-- [[shu-topological-grid]]
-
 ## Sources
 
 - Reference: [[fuersattel2016-ocpad]]

--- a/docs/atlas-vault/models/alexnet.md
+++ b/docs/atlas-vault/models/alexnet.md
@@ -1,0 +1,23 @@
+---
+title: "AlexNet"
+type: model
+slug: alexnet
+---
+
+> Generated stub — do not edit. Source: `content/models/alexnet.md`.
+
+Eight-layer convolutional neural network for 1000-class image classification on ImageNet, trained end-to-end on two GPUs with ReLU activations, local response normalisation, overlapping max-pooling, and dropout; the first deep CNN to win ILSVRC by a large margin.
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Lineage
+
+- **Extended by** — [[vgg]]
+  > VGG extends AlexNet's CNN classifier paradigm from 8 to 16/19 weight layers via stacked 3×3 conv blocks; same task, deeper architecture, same training framework.
+
+## Sources
+
+- Primary: [[krizhevsky2012-alexnet]]
+- Reference: [[szegedy2015-inception]]

--- a/docs/atlas-vault/models/bisenet.md
+++ b/docs/atlas-vault/models/bisenet.md
@@ -1,0 +1,28 @@
+---
+title: "BiSeNet"
+type: model
+slug: bisenet
+---
+
+> Generated stub — do not edit. Source: `content/models/bisenet.md`.
+
+Two-branch (bilateral) CNN for real-time semantic segmentation: a wide shallow path preserves spatial detail while a deep narrow path with global pooling supplies receptive field, merged by a learned fusion module. V1 (2018) pairs a Spatial Path and a Context Path (ARM + FFM) on an ImageNet-pretrained backbone; V2 (2020) redesigns it with a Detail Branch, a from-scratch Semantic Branch of Gather-and-Expansion layers, Bilateral Guided Aggregation, and a training-only Booster — 72.6% mIoU at 156 FPS on Cityscapes test (V2, Table 7).
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[deeplab-semantic-segmentation]]
+- **Compared with** — [[hrnet]] _(confidence: medium)_
+  > Both target spatial-detail loss in dense prediction — HRNet via a maintained high-resolution branch, BiSeNet via the Spatial/Detail Path.
+- **Compared with** — [[segformer]]
+
+## Sources
+
+- Primary: [[yu2018-bisenet]]
+- Reference: [[he2016-resnet]]
+- Reference: [[long2015-fcn]]
+- Reference: [[yu2020-bisenet]]

--- a/docs/atlas-vault/models/ccdn-checkerboard-detector.md
+++ b/docs/atlas-vault/models/ccdn-checkerboard-detector.md
@@ -12,13 +12,9 @@ Fully convolutional network that regresses a per-pixel checkerboard-corner respo
 
 - [[image-gradient]]
 
-## Related
+## Cross-paradigm
 
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[fast-corner-detector]]
-- [[harris-corner-detector]]
-- [[rochade]]
+- **Learned alternative of** — [[chess-corners]]
 
 ## Sources
 
@@ -27,3 +23,4 @@ Fully convolutional network that regresses a per-pixel checkerboard-corner respo
 - Reference: [[donne2016-mate]]
 - Reference: [[placht2014-rochade]]
 - Reference: [[rufli2008-blurred]]
+- Reference: [[zhang2022-learning-based]]

--- a/docs/atlas-vault/models/ccs-camera-calibration.md
+++ b/docs/atlas-vault/models/ccs-camera-calibration.md
@@ -1,0 +1,33 @@
+---
+title: "CCS"
+type: model
+slug: ccs-camera-calibration
+---
+
+> Generated stub — do not edit. Source: `content/models/ccs-camera-calibration.md`.
+
+Three-stage learning-based camera calibration pipeline: a CNN regresses radial-distortion-correction parameters, a UNet predicts per-corner Gaussian heatmaps refined by surface-fit subpixel localisation, and an image-level RANSAC accepts inlier views before Zhang-style intrinsic estimation.
+
+## Prerequisites
+
+- [[camera-distortion-models]]
+- [[chessboard-x-corner-detection]]
+- [[ransac]]
+
+## Practice
+
+- **Compared with** — [[ccdn-checkerboard-detector]]
+  > Peer at the corner-detection level only; CCS adds distortion correction and RANSAC parameter estimation on top.
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[chess-corners]]
+
+## Sources
+
+- Primary: [[zhang2022-learning-based]]
+- Reference: [[chen2023-ccdn]]
+- Reference: [[donne2016-mate]]
+- Reference: [[geiger2012-automatic]]
+- Reference: [[tsai1987-versatile]]
+- Reference: [[zhang2000-flexible]]

--- a/docs/atlas-vault/models/deeplab-semantic-segmentation.md
+++ b/docs/atlas-vault/models/deeplab-semantic-segmentation.md
@@ -1,0 +1,23 @@
+---
+title: "DeepLab"
+type: model
+slug: deeplab-semantic-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/models/deeplab-semantic-segmentation.md`.
+
+Dense semantic segmentation by repurposing an ImageNet classifier with atrous (dilated) convolution to preserve spatial resolution, an Atrous Spatial Pyramid Pooling head for multi-scale context, and a fully-connected CRF post-processor for boundary refinement — multi-year state of the art on PASCAL VOC 2012.
+
+## Practice
+
+- **Compared with** — [[unet-segmentation]]
+  > Same task, different mechanism — atrous backbone + multi-scale head + dense CRF vs symmetric encoder-decoder with skip concatenation.
+- **Feeds into** — [[mobilenetv3]] _(confidence: medium)_
+  > LR-ASPP is a lite, reduced reuse of DeepLab's ASPP as MobileNetV3's segmentation head.
+
+## Sources
+
+- Primary: [[chen2018-deeplab]]
+- Reference: [[he2016-resnet]]
+- Reference: [[long2015-fcn]]
+- Reference: [[ronneberger2015-unet]]

--- a/docs/atlas-vault/models/depth-anything-3.md
+++ b/docs/atlas-vault/models/depth-anything-3.md
@@ -1,0 +1,25 @@
+---
+title: "Depth Anything 3"
+type: model
+slug: depth-anything-3
+---
+
+> Generated stub — do not edit. Source: `content/models/depth-anything-3.md`.
+
+A single plain-transformer model that predicts spatially consistent geometry — depth plus camera rays — from one to many images, with or without known poses, distilled from Depth Anything 2 via a unified depth-ray target.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[feed-forward-3d-reconstruction]]
+- [[monocular-depth-estimation]]
+- [[pinhole-camera-model]]
+- [[pose-estimation]]
+
+## Sources
+
+- Primary: [[lin2025-depth-anything-3]]
+- Reference: [[oquab2023-dinov2]]
+- Reference: [[wang2023-dust3r]]
+- Reference: [[wang2025-vggt]]
+- Reference: [[yang2024-depth-anything-v2]]

--- a/docs/atlas-vault/models/depth-anything-v2.md
+++ b/docs/atlas-vault/models/depth-anything-v2.md
@@ -1,0 +1,26 @@
+---
+title: "Depth Anything V2"
+type: model
+slug: depth-anything-v2
+---
+
+> Generated stub — do not edit. Source: `content/models/depth-anything-v2.md`.
+
+A monocular depth foundation model that trains its teacher purely on synthetic images for label precision, then distills to a student over 62M pseudo-labeled real images, sharpening detail over V1 while staying far faster than diffusion-based depth.
+
+## Prerequisites
+
+- [[monocular-depth-estimation]]
+- [[vit]]
+
+## Lineage
+
+- **Generalised by** — [[depth-anything-3]]
+  > DA3 generalizes DA2 to any-view geometry and surpasses it on monocular depth; DA2 is also DA3's distillation teacher.
+
+## Sources
+
+- Primary: [[yang2024-depth-anything-v2]]
+- Reference: [[oquab2023-dinov2]]
+- Reference: [[ranftl2019-midas]]
+- Reference: [[yang2024-depth-anything]]

--- a/docs/atlas-vault/models/depth-anything.md
+++ b/docs/atlas-vault/models/depth-anything.md
@@ -1,0 +1,24 @@
+---
+title: "Depth Anything"
+type: model
+slug: depth-anything
+---
+
+> Generated stub — do not edit. Source: `content/models/depth-anything.md`.
+
+A monocular relative-depth foundation model that scales training to 62M unlabeled images via a teacher pseudo-labeling data engine, a CutMix challenge for the student, and a DINOv2 semantic-feature alignment loss.
+
+## Prerequisites
+
+- [[monocular-depth-estimation]]
+- [[vit]]
+
+## Lineage
+
+- **Extended by** — [[depth-anything-v2]]
+
+## Sources
+
+- Primary: [[yang2024-depth-anything]]
+- Reference: [[oquab2023-dinov2]]
+- Reference: [[ranftl2019-midas]]

--- a/docs/atlas-vault/models/detr.md
+++ b/docs/atlas-vault/models/detr.md
@@ -1,0 +1,28 @@
+---
+title: "DETR"
+type: model
+slug: detr
+---
+
+> Generated stub — do not edit. Source: `content/models/detr.md`.
+
+End-to-end object detector that recasts detection as direct set prediction — CNN backbone (ResNet-50/101) extracts $H/32 \times W/32$ feature map; transformer encoder-decoder with 6+6 layers and $N=100$ learned object queries outputs (class, box) pairs; bipartite-matching loss via Hungarian algorithm eliminates anchor boxes, region proposals, and NMS. Comparable COCO AP to Faster R-CNN at simpler pipeline; better large-object AP, worse small-object AP, and ~10× slower convergence (300+ epochs).
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[faster-rcnn]]
+  > DETR vs Faster R-CNN is the headline detection comparison; DETR removes hand-designed RPN + anchor boxes + NMS in favour of bipartite matching + transformer decoder at comparable COCO AP.
+- **Feeds into** — [[rf-detr]]
+  > RF-DETR is a DETR-family set-prediction detector; built on the DETR paradigm via its parents LW-DETR/Deformable-DETR.
+- **Feeds into** — [[sam]]
+  > SAM's mask decoder two-way cross-attention is inspired by DETR's transformer decoder; SAM 3's concept detector is explicitly DETR-based.
+
+## Sources
+
+- Primary: [[carion2020-detr]]
+- Reference: [[he2016-resnet]]

--- a/docs/atlas-vault/models/dinov2.md
+++ b/docs/atlas-vault/models/dinov2.md
@@ -1,0 +1,27 @@
+---
+title: "DINOv2"
+type: model
+slug: dinov2
+---
+
+> Generated stub — do not edit. Source: `content/models/dinov2.md`.
+
+A self-supervised ViT trained on a curated 142M-image dataset that yields general-purpose visual features usable frozen — via kNN or linear probes — for classification, dense depth and segmentation without finetuning.
+
+## Prerequisites
+
+- [[mae]]
+- [[vit]]
+
+## Practice
+
+- **Feeds into** — [[depth-anything]]
+- **Feeds into** — [[depth-anything-3]]
+- **Feeds into** — [[depth-anything-v2]]
+- **Feeds into** — [[vggt]]
+
+## Sources
+
+- Primary: [[oquab2023-dinov2]]
+- Reference: [[dosovitskiy2020-vit]]
+- Reference: [[he2021-mae]]

--- a/docs/atlas-vault/models/dust3r.md
+++ b/docs/atlas-vault/models/dust3r.md
@@ -1,0 +1,31 @@
+---
+title: "DUSt3R"
+type: model
+slug: dust3r
+---
+
+> Generated stub — do not edit. Source: `content/models/dust3r.md`.
+
+A feed-forward network that regresses two dense pointmaps in a shared coordinate frame from an uncalibrated, unposed image pair, jointly recovering correspondence, relative pose, intrinsics and depth without prior calibration.
+
+## Prerequisites
+
+- [[bundle-adjustment]]
+- [[epipolar-geometry]]
+- [[feed-forward-3d-reconstruction]]
+- [[pinhole-camera-model]]
+- [[pose-estimation]]
+
+## Lineage
+
+- **Extended by** — [[mast3r]]
+
+## Practice
+
+- **Feeds into** — [[depth-anything-3]] _(confidence: medium)_
+  > DA3 inherits DUSt3R's pose-free feed-forward pointmap paradigm but is a distinct any-view model.
+- **Feeds into** — [[vggt]]
+
+## Sources
+
+- Primary: [[wang2023-dust3r]]

--- a/docs/atlas-vault/models/fast-scnn.md
+++ b/docs/atlas-vault/models/fast-scnn.md
@@ -1,0 +1,26 @@
+---
+title: "Fast-SCNN"
+type: model
+slug: fast-scnn
+---
+
+> Generated stub — do not edit. Source: `content/models/fast-scnn.md`.
+
+Real-time semantic segmentation CNN whose shared shallow 'Learning to Downsample' prefix feeds both a deep low-resolution global-feature branch and a high-resolution detail skip, merged by a feature-fusion module — eliminating the duplicate early downsampling that two-branch segmenters pay. Built from depthwise-separable and MobileNetV2 inverted-residual blocks; ~1.11M parameters; 68.0% mIoU at 123.5 FPS on Cityscapes test (1024×2048, Titan Xp, Table 5).
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[bisenet]]
+- **Compared with** — [[deeplab-semantic-segmentation]]
+- **Compared with** — [[hrnet]] _(confidence: medium)_
+- **Compared with** — [[segformer]] _(confidence: medium)_
+
+## Sources
+
+- Primary: [[poudel2019-fast-scnn]]
+- Reference: [[long2015-fcn]]
+- Reference: [[yu2018-bisenet]]

--- a/docs/atlas-vault/models/faster-rcnn.md
+++ b/docs/atlas-vault/models/faster-rcnn.md
@@ -1,0 +1,27 @@
+---
+title: "Faster R-CNN"
+type: model
+slug: faster-rcnn
+---
+
+> Generated stub — do not edit. Source: `content/models/faster-rcnn.md`.
+
+Two-stage CNN object detector that replaces external Selective Search / EdgeBoxes proposals with a learned Region Proposal Network sharing conv features with the Fast R-CNN head — yielding near-real-time multi-class detection on GPU (5 fps with VGG-16) and ImageNet-pretrained backbones swapped freely from ZF through ResNet-101.
+
+## Lineage
+
+- **Extended by** — [[mask-rcnn]]
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[felzenszwalb-deformable-parts]]
+- **Learned alternative of** — [[viola-jones-detector]] _(confidence: medium)_
+  > Viola-Jones targets real-time face detection on CPUs; Faster R-CNN is general multi-class detection on GPUs — replacement is paradigm-level, not drop-in.
+
+## Sources
+
+- Primary: [[ren2015-faster]]
+- Reference: [[he2016-resnet]]
+- Reference: [[he2017-maskrcnn]]
+- Reference: [[krizhevsky2012-alexnet]]
+- Reference: [[long2015-fcn]]

--- a/docs/atlas-vault/models/fcn-semantic-segmentation.md
+++ b/docs/atlas-vault/models/fcn-semantic-segmentation.md
@@ -1,0 +1,30 @@
+---
+title: "FCN: Fully Convolutional Networks"
+type: model
+slug: fcn-semantic-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/models/fcn-semantic-segmentation.md`.
+
+Encoder-decoder CNN for dense pixel-wise classification — converts ImageNet classifiers into fully convolutional networks via 1×1-conv reinterpretation, then upsamples via learnable bilinear-initialised deconvolution with skip connections from earlier pooling stages.
+
+## Lineage
+
+- **Extended by** — [[deeplab-semantic-segmentation]]
+  > DeepLab adopts FCN's fully-convolutional framing but replaces strided downsampling with atrous (dilated) convolution to preserve resolution, adds an ASPP multi-scale head and a fully-connected CRF post-processor.
+- **Extended by** — [[unet-segmentation]]
+  > U-Net adapts the fully-convolutional framing to small-data biomedical regimes via symmetric decoder and skip concatenation.
+
+## Practice
+
+- **Feeds into** — [[bisenet]] _(confidence: medium)_
+  > BiSeNet's parallel branches both produce fractional-stride dense feature maps feeding a pixel-wise head, following the FCN framing; FCN-32s is its ablation baseline and FCN-8s a benchmark comparison.
+- **Feeds into** — [[fast-scnn]] _(confidence: medium)_
+  > Fast-SCNN frames itself as a special case of an FCN encoder-decoder with a single skip connection (§3.3.2); its classifier emits dense per-pixel logits upsampled to full resolution following the FCN template.
+- **Feeds into** — [[mask-rcnn]]
+  > Mask R-CNN adopts FCN's per-pixel binary prediction for the mask branch inside an instance-segmentation pipeline; mask branch is decoupled from class prediction.
+
+## Sources
+
+- Primary: [[long2015-fcn]]
+- Reference: [[he2016-resnet]]

--- a/docs/atlas-vault/models/focalclick.md
+++ b/docs/atlas-vault/models/focalclick.md
@@ -1,0 +1,20 @@
+---
+title: "FocalClick"
+type: model
+slug: focalclick
+---
+
+> Generated stub — do not edit. Source: `content/models/focalclick.md`.
+
+Practical click-based interactive segmentation that runs each click as a small local-crop forward pass (Segmentor on a Target Crop, Refiner on a Focus Crop) and composits results back via Progressive Merge — sub-300 ms per click on CPU with first-class support for refining preexisting masks.
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[grabcut-iterative-segmentation]] _(confidence: medium)_
+  > FocalClick replaces interactive click-based annotation workflows; not a drop-in for energy-min/graph-cut on seeded segmentation generally.
+
+## Sources
+
+- Primary: [[chen2022-focalclick]]
+- Reference: [[sofiiuk2021-ritm]]
+- Reference: [[sun2019-hrnet]]

--- a/docs/atlas-vault/models/googlenet.md
+++ b/docs/atlas-vault/models/googlenet.md
@@ -1,0 +1,31 @@
+---
+title: "GoogLeNet"
+type: model
+slug: googlenet
+---
+
+> Generated stub — do not edit. Source: `content/models/googlenet.md`.
+
+Twenty-two-layer CNN built from Inception modules — parallel 1×1, 3×3, 5×5 convolutions and 3×3 max-pool concatenated along the channel axis, with 1×1 bottlenecks reducing dimensionality before the larger spatial convs. ILSVRC-2014 classification winner at 6.67% top-5 error with 7M parameters (12× fewer than AlexNet).
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Lineage
+
+- **Parallel foundation with** — [[vgg]]
+  > Both ILSVRC-2014 entries — GoogLeNet won classification (6.67% top-5), VGG won localisation. Different design philosophies: Inception modules vs homogeneous 3×3 depth scaling.
+
+## Practice
+
+- **Compared with** — [[alexnet]]
+  > 22 layers vs AlexNet's 8; 7M vs 60M parameters; 56.5% relative reduction in top-5 error vs AlexNet (16.4% → 6.67%) over two ILSVRC years.
+- **Feeds into** — [[fcn-semantic-segmentation]] _(confidence: medium)_
+  > One of three backbones explored in FCN; FCN-GoogLeNet 42.5 mean IU vs FCN-VGG16 56.0 (FCN Table 1) — aggressive early downsampling hurts dense prediction.
+
+## Sources
+
+- Primary: [[szegedy2015-inception]]
+- Reference: [[krizhevsky2012-alexnet]]
+- Reference: [[simonyan2014-vgg]]

--- a/docs/atlas-vault/models/hrnet.md
+++ b/docs/atlas-vault/models/hrnet.md
@@ -1,0 +1,28 @@
+---
+title: "HRNet"
+type: model
+slug: hrnet
+---
+
+> Generated stub — do not edit. Source: `content/models/hrnet.md`.
+
+CNN backbone family for dense prediction that maintains a high-resolution branch throughout the network and runs four parallel multi-resolution streams ($C, 2C, 4C, 8C$ channels) with eight repeated cross-resolution fusions; V1 uses the high-resolution stream only (pose heatmaps), V2 upsamples and concatenates all four streams for per-pixel labelling (semantic segmentation, face landmarks), and V2p adds an FPN-style multi-scale output for object detection and instance segmentation.
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[resnet]] _(confidence: medium)_
+  > ResNet is the dominant backbone for dense prediction; HRNet trades higher activation memory for better keypoint/segmentation accuracy via parallel high-resolution streams.
+- **Feeds into** — [[focalclick]]
+  > FocalClick uses HRNet18s+OCR and HRNet32+OCR as the Segmentor backbone in three of its six published variants (hrnet18s-S1/S2, hrnet32-S2); the small-crop Segmentor input (128×128 or 256×256) makes HRNet practical for CPU deployment.
+- **Feeds into** — [[ritm-interactive-segmentation]]
+
+## Sources
+
+- Primary: [[sun2019-hrnet]]
+- Reference: [[he2016-resnet]]
+- Reference: [[sun2019-hrnetv2]]
+- Reference: [[wang2020-hrnet-journal]]

--- a/docs/atlas-vault/models/lightglue.md
+++ b/docs/atlas-vault/models/lightglue.md
@@ -1,0 +1,22 @@
+---
+title: "LightGlue"
+type: model
+slug: lightglue
+---
+
+> Generated stub — do not edit. Source: `content/models/lightglue.md`.
+
+Adaptive-depth Transformer matcher for sparse local features: stacks 9 self+cross-attention layers with rotary positional encoding and a per-token confidence head, exits early on easy image pairs, and replaces SuperGlue's Sinkhorn solver with a dual-softmax × matchability assignment head — over 2× faster than SuperGlue at equivalent or better pose-estimation accuracy.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[feature-matching]]
+
+## Sources
+
+- Primary: [[lindenberger2023-lightglue]]
+- Reference: [[detone2018-superpoint]]
+- Reference: [[lowe2004-sift]]
+- Reference: [[sarlin2020-superglue]]
+- Reference: [[sun2021-loftr]]

--- a/docs/atlas-vault/models/loftr.md
+++ b/docs/atlas-vault/models/loftr.md
@@ -1,0 +1,30 @@
+---
+title: "LoFTR"
+type: model
+slug: loftr
+---
+
+> Generated stub — do not edit. Source: `content/models/loftr.md`.
+
+Detector-free dense feature matcher: shared CNN backbone produces coarse and fine feature maps, a Linear Transformer with interleaved self- and cross-attention establishes confidence-thresholded mutual nearest-neighbour correspondences, and a fine module refines each match to sub-pixel accuracy.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[feature-matching]]
+
+## Practice
+
+- **Compared with** — [[lightglue]]
+  > Different paradigm — LoFTR is detector-free dense; LightGlue is detector-based sparse with adaptive depth. LoFTR wins in textureless regions; LightGlue wins on speed (~8× faster per Lindenberger et al. Fig. 1).
+- **Compared with** — [[xfeat]]
+  > XFeat is later and lighter; LoFTR is the heavyweight reference for the detector-free paradigm.
+
+## Sources
+
+- Primary: [[sun2021-loftr]]
+- Reference: [[detone2018-superpoint]]
+- Reference: [[he2016-resnet]]
+- Reference: [[lindenberger2023-lightglue]]
+- Reference: [[potje2024-xfeat]]
+- Reference: [[sarlin2020-superglue]]

--- a/docs/atlas-vault/models/mae.md
+++ b/docs/atlas-vault/models/mae.md
@@ -1,0 +1,25 @@
+---
+title: "MAE"
+type: model
+slug: mae
+---
+
+> Generated stub — do not edit. Source: `content/models/mae.md`.
+
+Masked Autoencoder — self-supervised pretraining for Vision Transformers: randomly mask 75 % of input patches, feed the visible 25 % through a ViT encoder, then run a lightweight ViT decoder over the full sequence (visible + shared learnable mask tokens) to reconstruct the masked patches' raw pixel values under MSE on per-patch-normalised targets. The asymmetric encoder-decoder design (encoder operates only on visible tokens, decoder is much smaller and discarded after pretraining) gives a 2.8–4.1× pretraining speedup vs full-sequence masked-ViT baselines and reaches 87.8 % ImageNet-1k top-1 with ViT-H fine-tuning.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Feeds into** — [[sam]]
+  > SAM v1's ViT-H image encoder is MAE-pretrained; SAM 2's Hiera (hierarchical ViT) is also MAE-pretrained. MAE is the SSL recipe that makes the SAM-family foundation segmenters' large encoders feasible.
+
+## Sources
+
+- Primary: [[he2021-mae]]
+- Reference: [[dosovitskiy2020-vit]]
+- Reference: [[he2016-resnet]]

--- a/docs/atlas-vault/models/mask-rcnn.md
+++ b/docs/atlas-vault/models/mask-rcnn.md
@@ -1,0 +1,21 @@
+---
+title: "Mask R-CNN"
+type: model
+slug: mask-rcnn
+---
+
+> Generated stub — do not edit. Source: `content/models/mask-rcnn.md`.
+
+Two-stage instance segmentation by adding a parallel FCN mask branch to Faster R-CNN — per-class binary masks predicted at each RoI under a decoupled per-pixel sigmoid loss, with RoIAlign's bilinear-sampling replacement for RoIPool's quantization that recovers pixel-accurate alignment.
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[felzenszwalb-deformable-parts]] _(confidence: medium)_
+  > Mask R-CNN's CNN backbone, region proposals, and RoIAlign replace DPM's HOG features, root + part filters, and latent-SVM scoring; Mask R-CNN also outputs per-instance masks beyond DPM's bounding boxes.
+
+## Sources
+
+- Primary: [[he2017-maskrcnn]]
+- Reference: [[he2016-resnet]]
+- Reference: [[long2015-fcn]]
+- Reference: [[ren2015-faster]]

--- a/docs/atlas-vault/models/mask2former.md
+++ b/docs/atlas-vault/models/mask2former.md
@@ -1,0 +1,28 @@
+---
+title: "Mask2Former"
+type: model
+slug: mask2former
+---
+
+> Generated stub — do not edit. Source: `content/models/mask2former.md`.
+
+Universal image segmentation family — MaskFormer (v1, NeurIPS 2021) reframes semantic segmentation as **mask classification**: predict a set of $N$ binary masks plus per-mask class labels via a DETR-style transformer decoder over pixel-decoder features, supervised by bipartite matching. Mask2Former (v2, CVPR 2022) extends v1 with **masked attention** (cross-attention restricted to each query's predicted mask foreground), multi-scale round-robin features (queries cross-attend to 1/32, 1/16, 1/8 maps across consecutive layers), and point-sampled mask loss for 3× memory reduction. A single architecture, trained per-dataset, beats specialised models on COCO panoptic (PQ 57.8), COCO instance (AP 50.1), and ADE20K semantic (mIoU 57.7) with Swin-L.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[mask-rcnn]]
+  > Mask R-CNN is the dominant per-RoI proposal-then-segment baseline; Mask2Former reframes the same problem as mask classification + set prediction, achieving unified handling of semantic, instance, and panoptic in one architecture.
+- **Feeds into** — [[sam]]
+  > SAM 3's mask head is adapted from MaskFormer/Mask2Former — this family establishes the per-query mask classification + set-prediction paradigm SAM 3 inherits for concept segmentation.
+
+## Sources
+
+- Primary: [[cheng2022-mask2former]]
+- Reference: [[carion2020-detr]]
+- Reference: [[cheng2021-maskformer]]
+- Reference: [[he2016-resnet]]

--- a/docs/atlas-vault/models/mast3r.md
+++ b/docs/atlas-vault/models/mast3r.md
@@ -1,0 +1,29 @@
+---
+title: "MASt3R"
+type: model
+slug: mast3r
+---
+
+> Generated stub — do not edit. Source: `content/models/mast3r.md`.
+
+A 3D-grounded image matcher that adds a dense local-descriptor head and an InfoNCE matching loss on top of DUSt3R's pointmap regression, with a fast reciprocal matching scheme, yielding correspondences robust to extreme viewpoint change.
+
+## Prerequisites
+
+- [[epipolar-geometry]]
+- [[feature-descriptors]]
+- [[feature-matching]]
+- [[feed-forward-3d-reconstruction]]
+- [[pose-estimation]]
+
+## Practice
+
+- **Compared with** — [[lightglue]] _(confidence: medium)_
+  > MASt3R is 3D-grounded and pose-robust; LightGlue is a fast sparse 2D matcher.
+- **Compared with** — [[loftr]] _(confidence: medium)_
+  > MASt3R grounds matching in 3D and wins under extreme viewpoint change; LoFTR is a 2D detector-free matcher.
+
+## Sources
+
+- Primary: [[leroy2024-mast3r]]
+- Reference: [[wang2023-dust3r]]

--- a/docs/atlas-vault/models/mate-checkerboard-detector.md
+++ b/docs/atlas-vault/models/mate-checkerboard-detector.md
@@ -12,16 +12,15 @@ First learned per-pixel checkerboard X-corner detector: a three-convolutional-la
 
 - [[image-gradient]]
 
-## Related
+## Practice
 
-- [[chess-corners]]
-- [[chessboard-x-corner-detection]]
-- [[fast-corner-detector]]
-- [[rochade]]
+- **Compared with** — [[ccdn-checkerboard-detector]]
+- **Compared with** — [[ccs-camera-calibration]]
+  > Different scope: MATE is a detector, CCS is a full calibration pipeline; comparison is at the corner-detection level.
 
-## Compared with
+## Cross-paradigm
 
-- [[ccdn-checkerboard-detector]]
+- **Learned alternative of** — [[chess-corners]]
 
 ## Sources
 
@@ -30,3 +29,4 @@ First learned per-pixel checkerboard X-corner detector: a three-convolutional-la
 - Reference: [[chen2023-ccdn]]
 - Reference: [[placht2014-rochade]]
 - Reference: [[rufli2008-blurred]]
+- Reference: [[zhang2022-learning-based]]

--- a/docs/atlas-vault/models/midas.md
+++ b/docs/atlas-vault/models/midas.md
@@ -1,0 +1,22 @@
+---
+title: "MiDaS"
+type: model
+slug: midas
+---
+
+> Generated stub — do not edit. Source: `content/models/midas.md`.
+
+A monocular depth network trained for zero-shot cross-dataset transfer by mixing incompatible depth datasets under a scale-and-shift-invariant loss, predicting relative inverse depth up to an unknown global scale and shift.
+
+## Prerequisites
+
+- [[monocular-depth-estimation]]
+- [[pinhole-camera-model]]
+
+## Practice
+
+- **Feeds into** — [[depth-anything]]
+
+## Sources
+
+- Primary: [[ranftl2019-midas]]

--- a/docs/atlas-vault/models/mnasnet.md
+++ b/docs/atlas-vault/models/mnasnet.md
@@ -1,0 +1,24 @@
+---
+title: "MnasNet"
+type: model
+slug: mnasnet
+---
+
+> Generated stub — do not edit. Source: `content/models/mnasnet.md`.
+
+Mobile-CPU CNN image classifier discovered by platform-aware neural architecture search: an RNN controller trained with reinforcement learning samples architectures from a factorized hierarchical search space and maximizes a multi-objective reward trading ImageNet top-1 accuracy against latency measured directly on a phone.
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Feeds into** — [[mobilenetv3]]
+  > MobileNetV3 uses MnasNet-style platform-aware NAS and the SE-augmented search space as the basis of its block-level search.
+
+## Sources
+
+- Primary: [[tan2019-mnasnet]]
+- Reference: [[howard2019-mobilenetv3]]
+- Reference: [[sandler2018-mobilenetv2]]

--- a/docs/atlas-vault/models/mobilenetv2.md
+++ b/docs/atlas-vault/models/mobilenetv2.md
@@ -1,0 +1,30 @@
+---
+title: "MobileNetV2"
+type: model
+slug: mobilenetv2
+---
+
+> Generated stub — do not edit. Source: `content/models/mobilenetv2.md`.
+
+Efficient mobile CNN backbone built from inverted-residual blocks with a linear bottleneck — depthwise-separable convolution expanded to a wide interior and projected back to a thin, non-linearity-free bottleneck that the residual connects — for on-device classification, detection (SSDLite), and segmentation (Mobile DeepLabv3).
+
+## Prerequisites
+
+- [[convolution]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Feeds into** — [[fast-scnn]]
+  > Fast-SCNN's Global Feature Extractor is built from MobileNetV2 inverted-residual bottlenecks.
+- **Feeds into** — [[mnasnet]] _(confidence: medium)_
+  > MnasNet's MBConv search space is built on MobileNetV2's inverted-residual block.
+- **Feeds into** — [[mobilenetv3]]
+  > MobileNetV3 inherits the inverted-residual + linear-bottleneck block as its core building primitive.
+
+## Sources
+
+- Primary: [[sandler2018-mobilenetv2]]
+- Reference: [[he2016-resnet]]
+- Reference: [[howard2019-mobilenetv3]]
+- Reference: [[tan2019-mnasnet]]

--- a/docs/atlas-vault/models/mobilenetv3.md
+++ b/docs/atlas-vault/models/mobilenetv3.md
@@ -1,0 +1,30 @@
+---
+title: "MobileNetV3"
+type: model
+slug: mobilenetv3
+---
+
+> Generated stub — do not edit. Source: `content/models/mobilenetv3.md`.
+
+Mobile-CPU-latency-targeted CNN backbone found by combined platform-aware NAS and NetAdapt, built from MobileNetV2 inverted-residual blocks augmented with squeeze-and-excitation and the h-swish nonlinearity, plus a Lite Reduced ASPP segmentation decoder; trained on ImageNet-1k and adapted to detection and segmentation.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolution]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[bisenet]] _(confidence: medium)_
+  > Peer comparison in the real-time mobile segmentation regime.
+- **Compared with** — [[fast-scnn]] _(confidence: medium)_
+  > Peer comparison is specific to the real-time Cityscapes segmentation regime.
+
+## Sources
+
+- Primary: [[howard2019-mobilenetv3]]
+- Reference: [[chen2018-deeplab]]
+- Reference: [[long2015-fcn]]
+- Reference: [[sandler2018-mobilenetv2]]
+- Reference: [[tan2019-mnasnet]]

--- a/docs/atlas-vault/models/mobilesam.md
+++ b/docs/atlas-vault/models/mobilesam.md
@@ -1,0 +1,25 @@
+---
+title: "MobileSAM"
+type: model
+slug: mobilesam
+---
+
+> Generated stub — do not edit. Source: `content/models/mobilesam.md`.
+
+Lightweight SAM family — replaces SAM's heavy ViT-H image encoder (632M params, ~452 ms on a single GPU) with a distilled TinyViT encoder (5.78M params, ~8 ms), keeping SAM's prompt encoder + mask decoder frozen and unchanged; MobileSAMv2 adds an object-aware prompt sampler (YOLOv8-style detector → bounding-box prompts) that replaces SAM's 32×32 grid-prompt + NMS pipeline for the Segment-Everything task, cutting end-to-end latency from ≈1616 ms to ≈97 ms (>16×) at equivalent mask quality.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[sam]]
+
+## Practice
+
+- **Compared with** — [[focalclick]] _(confidence: medium)_
+  > Both target lightweight on-device interactive segmentation but from different lineages — MobileSAM distils SAM's foundation-model encoder into TinyViT (zero-shot, no mask correction); FocalClick is a small specialised two-stage network with native preexisting-mask refinement.
+
+## Sources
+
+- Primary: [[zhang2023-mobilesam]]
+- Reference: [[kirillov2023-sam]]
+- Reference: [[zhang2023-mobilesamv2]]

--- a/docs/atlas-vault/models/resnet.md
+++ b/docs/atlas-vault/models/resnet.md
@@ -1,0 +1,32 @@
+---
+title: "ResNet"
+type: model
+slug: resnet
+---
+
+> Generated stub — do not edit. Source: `content/models/resnet.md`.
+
+Family of very deep CNN image classifiers (18 to 152 layers) built from residual blocks $y = \mathcal{F}(x, \{W_i\}) + x$ that reformulate each block as learning a residual mapping rather than a direct one, resolving the depth-degradation problem and enabling 152-layer training. ILSVRC-2015 classification winner (3.57% top-5 test ensemble) and the default backbone for downstream detection and segmentation.
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[googlenet]]
+  > Both push depth beyond VGG: GoogLeNet 22 layers via Inception modules, ResNet up to 152 via residual blocks. ResNet-152 single model 4.49% top-5 val vs GoogLeNet ensemble 6.66% top-5 test (Tables 4/5).
+- **Feeds into** — [[deeplab-semantic-segmentation]]
+  > DeepLab v2 onward uses ResNet-101 as the dense-prediction backbone; v1 used VGG-16.
+- **Feeds into** — [[loftr]] _(confidence: medium)_
+  > LoFTR's local-feature CNN is a ResNet-like backbone with FPN structure.
+- **Feeds into** — [[mask-rcnn]]
+  > Mask R-CNN's headline backbones are ResNet-50/101 and ResNeXt-101 paired with FPN.
+
+## Sources
+
+- Primary: [[he2016-resnet]]
+- Reference: [[krizhevsky2012-alexnet]]
+- Reference: [[long2015-fcn]]
+- Reference: [[simonyan2014-vgg]]
+- Reference: [[szegedy2015-inception]]

--- a/docs/atlas-vault/models/rf-detr.md
+++ b/docs/atlas-vault/models/rf-detr.md
@@ -1,0 +1,20 @@
+---
+title: "RF-DETR"
+type: model
+slug: rf-detr
+---
+
+> Generated stub — do not edit. Source: `content/models/rf-detr.md`.
+
+Light-weight specialist real-time detection transformer that discovers an accuracy-latency Pareto frontier for any target dataset from a single training run: a DINOv2-ViT backbone feeds an LW-DETR-style set-prediction decoder, and weight-sharing NAS evaluates thousands of sub-network configurations without retraining. First real-time detector to exceed 60 AP on COCO.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Sources
+
+- Primary: [[robinson2025-rf-detr]]
+- Reference: [[carion2020-detr]]
+- Reference: [[dosovitskiy2020-vit]]

--- a/docs/atlas-vault/models/ritm-interactive-segmentation.md
+++ b/docs/atlas-vault/models/ritm-interactive-segmentation.md
@@ -1,0 +1,26 @@
+---
+title: "RITM"
+type: model
+slug: ritm-interactive-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/models/ritm-interactive-segmentation.md`.
+
+Feedforward click-based interactive segmentation: HRNet+OCR encoder-decoder taking RGB + positive/negative disk-encoded clicks + previous mask, trained with iterative click simulation and Normalized Focal Loss on COCO+LVIS — sets a new state of the art without inference-time backward passes.
+
+## Lineage
+
+- **Extended by** — [[focalclick]]
+  > FocalClick adds Focus View + Progressive Merge for CPU-feasible mask correction; RITM remains the foundational feedforward click-based reference.
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[grabcut-iterative-segmentation]]
+- **Learned alternative of** — [[graph-cut-segmentation]] _(confidence: medium)_
+  > RITM replaces interactive (click-seeded) graph-cut workflows; not all energy-min segmentation.
+
+## Sources
+
+- Primary: [[sofiiuk2021-ritm]]
+- Reference: [[chen2018-deeplab]]
+- Reference: [[sun2019-hrnet]]

--- a/docs/atlas-vault/models/sam.md
+++ b/docs/atlas-vault/models/sam.md
@@ -1,0 +1,40 @@
+---
+title: "SAM"
+type: model
+slug: sam
+---
+
+> Generated stub — do not edit. Source: `content/models/sam.md`.
+
+Promptable segmentation foundation model family — SAM (v1, 2023) introduces image-prompt segmentation with a heavy ViT-H encoder and lightweight transformer decoder trained on the 1.1B-mask SA-1B dataset; SAM 2 (2024) extends to video via a streaming memory module on a Hiera hierarchical-ViT encoder; SAM 3 (2025) generalises from single-object prompts to *concept* prompts (free-form noun phrases or visual exemplars) via a presence token, segmenting all matching instances on images and videos.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Lineage
+
+- **Extended by** — [[mobilesam]]
+  > MobileSAM is a lightweight derivative — distils SAM v1's ViT-H image encoder into a 5.78M-param TinyViT (~56× faster) while keeping SAM's prompt encoder + decoder frozen; MobileSAMv2 adds an object-aware prompt sampler for Segment-Everything.
+
+## Practice
+
+- **Compared with** — [[focalclick]] _(confidence: medium)_
+  > Opposite design points — SAM is a heavy promptable foundation model with zero-shot generalisation but no preexisting-mask refinement; FocalClick is a small specialised network with native mask correction but no zero-shot.
+- **Compared with** — [[mask-rcnn]] _(confidence: medium)_
+  > Different problem classes — Mask R-CNN is closed-set instance detection with category labels; SAM is class-agnostic promptable segmentation.
+- **Compared with** — [[ritm-interactive-segmentation]] _(confidence: medium)_
+  > Both are click-prompted interactive segmenters; different sub-paradigms — SAM is a foundation model with a prompt-conditioned decoder, RITM is iterative-mask refinement on a per-image encoder.
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[felzenszwalb-graph-segmentation]]
+- **Learned alternative of** — [[grabcut-iterative-segmentation]]
+- **Learned alternative of** — [[graph-cut-segmentation]]
+
+## Sources
+
+- Primary: [[kirillov2023-sam]]
+- Reference: [[carion2025-sam3]]
+- Reference: [[ravi2024-sam2]]

--- a/docs/atlas-vault/models/segformer.md
+++ b/docs/atlas-vault/models/segformer.md
@@ -1,0 +1,33 @@
+---
+title: "SegFormer"
+type: model
+slug: segformer
+---
+
+> Generated stub — do not edit. Source: `content/models/segformer.md`.
+
+Hierarchical Transformer encoder (MiT) producing multi-scale features at $1/4, 1/8, 1/16, 1/32$ without positional encodings, plus an all-MLP decoder that fuses per-stage features into a per-pixel prediction. Six variants MiT-B0..B5 trade compute for accuracy; B5 reaches 51.8 mIoU on ADE20K and 84.0 mIoU on Cityscapes (Tables 1 and 2).
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[deeplab-semantic-segmentation]]
+- **Compared with** — [[fcn-semantic-segmentation]]
+- **Compared with** — [[hrnet]]
+- **Compared with** — [[mask2former]] _(confidence: medium)_
+  > Mask2Former 2022 follows SegFormer 2021 with a mask-classification paradigm; different formulation (set prediction over masks vs per-pixel).
+- **Compared with** — [[unet-segmentation]] _(confidence: medium)_
+  > U-Net is the encoder-decoder ancestor; SegFormer keeps the multi-scale-fuse idea but drops skip connections in favour of MLP-aggregating decoder.
+- **Feeds into** — [[focalclick]]
+  > SegFormer-B0 and SegFormer-B3 are explicit Segmentor backbones in FocalClick Table 3; the MiT encoder + all-MLP decoder is reused intact and the decoder logits feed FocalClick's Refiner.
+
+## Sources
+
+- Primary: [[xie2021-segformer]]
+- Reference: [[chen2018-deeplab]]
+- Reference: [[dosovitskiy2020-vit]]
+- Reference: [[long2015-fcn]]

--- a/docs/atlas-vault/models/superglue.md
+++ b/docs/atlas-vault/models/superglue.md
@@ -1,0 +1,30 @@
+---
+title: "SuperGlue"
+type: model
+slug: superglue
+---
+
+> Generated stub — do not edit. Source: `content/models/superglue.md`.
+
+Graph neural network that matches two sets of sparse local features by jointly finding correspondences and rejecting unmatched keypoints in one differentiable forward pass, trained end-to-end with a Sinkhorn optimal-transport assignment over augmented dustbin scores.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[feature-matching]]
+
+## Lineage
+
+- **Extended by** — [[lightglue]]
+  > LightGlue retains SuperGlue's graph-attention matcher framework; adds adaptive depth + token pruning + dual-softmax head for >2× speedup at comparable or better accuracy. SuperGlue remains the reference baseline.
+
+## Practice
+
+- **Compared with** — [[loftr]]
+
+## Sources
+
+- Primary: [[sarlin2020-superglue]]
+- Reference: [[detone2018-superpoint]]
+- Reference: [[lindenberger2023-lightglue]]
+- Reference: [[sun2021-loftr]]

--- a/docs/atlas-vault/models/superpoint.md
+++ b/docs/atlas-vault/models/superpoint.md
@@ -12,15 +12,27 @@ Fully-convolutional CNN that jointly detects interest points and computes 256-D 
 
 - [[image-gradient]]
 
-## Related
+## Practice
 
-- [[fast-corner-detector]]
-- [[harris-corner-detector]]
-- [[shi-tomasi-corner-detector]]
+- **Compared with** — [[xfeat]]
+- **Feeds into** — [[lightglue]]
+  > LightGlue ships SuperPoint-paired pretrained weights as the default configuration; recommended over SuperGlue for new pipelines (faster, Apache-2.0).
+- **Feeds into** — [[superglue]]
+  > SuperGlue is the canonical learned matcher paired with SuperPoint; SuperPoint keypoints + descriptors are SuperGlue's typical front-end.
 
-## Compared with
+## Cross-paradigm
 
-- [[xfeat]]
+- **Learned alternative of** — [[brief]]
+  > SuperPoint replaces the FAST+BRIEF / SIFT / ORB classical pipeline with a single learned encoder + decoder heads.
+- **Learned alternative of** — [[harris-corner-detector]]
+  > SuperPoint replaces classical sparse keypoint+descriptor pipelines (Harris/Shi-Tomasi + SIFT/ORB) with a single learned model; it does not literally re-implement the Harris response.
+- **Learned alternative of** — [[orb]]
+  > SuperPoint replaces ORB's oFAST + rBRIEF detector-descriptor bundle with a single learned encoder + dual decoder heads; descriptor matching is float-valued L2 instead of Hamming.
+- **Learned alternative of** — [[shi-tomasi-corner-detector]]
+- **Learned alternative of** — [[sift]]
+  > SuperPoint replaces SIFT's hand-crafted DoG + 128-D descriptor with a single learned encoder + dual decoder heads.
+- **Learned alternative of** — [[surf]]
+  > SuperPoint replaces SURF's box-filter Hessian detector + 64-D Haar-wavelet descriptor with a learned VGG encoder + dual decoder heads.
 
 ## Sources
 

--- a/docs/atlas-vault/models/unet-segmentation.md
+++ b/docs/atlas-vault/models/unet-segmentation.md
@@ -1,0 +1,14 @@
+---
+title: "U-Net"
+type: model
+slug: unet-segmentation
+---
+
+> Generated stub — do not edit. Source: `content/models/unet-segmentation.md`.
+
+Symmetric encoder-decoder fully-convolutional network for dense pixel-wise biomedical image segmentation — contracting path with channel-doubling 3×3 convs and max-pool downsampling, expansive path with up-convs and skip concatenation of cropped encoder features, trained from scratch on tens of images via heavy elastic-deformation augmentation and a distance-weighted cross-entropy loss that learns inter-instance separation borders.
+
+## Sources
+
+- Primary: [[ronneberger2015-unet]]
+- Reference: [[long2015-fcn]]

--- a/docs/atlas-vault/models/vgg.md
+++ b/docs/atlas-vault/models/vgg.md
@@ -1,0 +1,31 @@
+---
+title: "VGG"
+type: model
+slug: vgg
+---
+
+> Generated stub — do not edit. Source: `content/models/vgg.md`.
+
+Family of very deep CNN image classifiers (11 to 19 weight layers) built from stacked 3×3 convolutions with stride 1 and 2×2 max-pool stride 2, trained on ImageNet with SGD + dropout. ILSVRC-2014 localisation winner and classification runner-up.
+
+## Prerequisites
+
+- [[convolutional-neural-network]]
+
+## Lineage
+
+- **Extended by** — [[resnet]]
+  > ResNet reformulates VGG-style plain depth scaling: identity shortcuts let 152-layer nets train where 19-layer plain nets already plateau (ResNet §1, Fig. 1).
+
+## Practice
+
+- **Feeds into** — [[deeplab-semantic-segmentation]]
+  > DeepLab v1 uses VGG-16 backbone; later versions switched to ResNet/Xception.
+- **Feeds into** — [[fcn-semantic-segmentation]]
+  > VGG-16 is FCN's canonical backbone per FCN Table 1; FCN-VGG16 mean IU 56.0 vs FCN-AlexNet 39.8.
+
+## Sources
+
+- Primary: [[simonyan2014-vgg]]
+- Reference: [[krizhevsky2012-alexnet]]
+- Reference: [[szegedy2015-inception]]

--- a/docs/atlas-vault/models/vggt.md
+++ b/docs/atlas-vault/models/vggt.md
@@ -1,0 +1,30 @@
+---
+title: "VGGT (Visual Geometry Grounded Transformer)"
+type: model
+slug: vggt
+---
+
+> Generated stub — do not edit. Source: `content/models/vggt.md`.
+
+A large feed-forward transformer that predicts cameras, depth maps, point maps and 3D point tracks for one to hundreds of views in a single pass, removing the optimization and global-alignment post-processing that pairwise pointmap methods require.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[bundle-adjustment]]
+- [[epipolar-geometry]]
+- [[feed-forward-3d-reconstruction]]
+- [[pose-estimation]]
+- [[vit]]
+
+## Lineage
+
+- **Generalised by** — [[depth-anything-3]] _(confidence: medium)_
+  > DA3 surpasses VGGT on the any-view benchmark (+44% pose, +25% geometry) and adds pose-conditioned input; VGGT remains a strong, widely-used feed-forward baseline.
+
+## Sources
+
+- Primary: [[wang2025-vggt]]
+- Reference: [[leroy2024-mast3r]]
+- Reference: [[oquab2023-dinov2]]
+- Reference: [[wang2023-dust3r]]

--- a/docs/atlas-vault/models/vit.md
+++ b/docs/atlas-vault/models/vit.md
@@ -1,0 +1,28 @@
+---
+title: "ViT"
+type: model
+slug: vit
+---
+
+> Generated stub — do not edit. Source: `content/models/vit.md`.
+
+Vision Transformer — a pure-transformer image classification backbone that treats an image as a sequence of fixed-size patches: split RGB image into $N = HW/P^2$ patches of $P{\times}P$ pixels (P=16 for ViT-B/L, P=14 for ViT-H), linearly project to $D$-dim tokens, prepend a learnable [CLS] token, add learned positional embeddings, and feed through a standard transformer encoder; classification head reads the [CLS] token's final-layer output. ViT-B/16 86M params, ViT-L/16 307M, ViT-H/14 632M. With large-scale pretraining (JFT-300M) ViT matches or exceeds ResNet-based BiT-L on ImageNet at lower compute.
+
+## Prerequisites
+
+- [[attention-mechanism]]
+- [[convolutional-neural-network]]
+
+## Practice
+
+- **Compared with** — [[resnet]]
+  > ViT vs ResNet (BiT) is the headline classification comparison in the paper. Both coexist as production backbones — ResNet's conv inductive bias dominates in small-data regimes; ViT scales better with large pretraining (JFT-300M).
+- **Feeds into** — [[mobilesam]]
+- **Feeds into** — [[rf-detr]] _(confidence: medium)_
+  > RF-DETR's backbone is a DINOv2 self-supervised ViT.
+- **Feeds into** — [[sam]]
+
+## Sources
+
+- Primary: [[dosovitskiy2020-vit]]
+- Reference: [[he2016-resnet]]

--- a/docs/atlas-vault/models/xfeat.md
+++ b/docs/atlas-vault/models/xfeat.md
@@ -12,6 +12,17 @@ Lightweight CNN that jointly detects keypoints, extracts 64-D dense descriptors,
 
 - [[image-gradient]]
 
+## Cross-paradigm
+
+- **Learned alternative of** — [[brief]]
+  > XFeat replaces the FAST+BRIEF binary-descriptor pipeline with a featherweight learned model targeting CPU inference.
+- **Learned alternative of** — [[orb]]
+  > XFeat targets ORB-class deployment budgets (mobile, real-time, low-power CPU) and replaces ORB's hand-crafted oFAST + rBRIEF binary pipeline with a learned 64-D float descriptor.
+- **Learned alternative of** — [[sift]]
+  > XFeat targets CPU-grade compute and replaces SIFT's classical hand-crafted pipeline with a featherweight learned model.
+- **Learned alternative of** — [[surf]]
+  > XFeat replaces SURF's integral-image Hessian detector + Haar-wavelet descriptor with a featherweight learned model targeting CPU inference.
+
 ## Sources
 
 - Primary: [[potje2024-xfeat]]

--- a/docs/atlas-vault/models/yolo-v1.md
+++ b/docs/atlas-vault/models/yolo-v1.md
@@ -1,0 +1,28 @@
+---
+title: "YOLOv1"
+type: model
+slug: yolo-v1
+---
+
+> Generated stub — do not edit. Source: `content/models/yolo-v1.md`.
+
+Single-stage CNN object detector that frames detection as one regression problem from full-image pixels to a 7×7×30 tensor of grid-cell box offsets, objectness, and 20-class probabilities — trained end-to-end and inferring 98 boxes per image at 45 fps on a Titan X.
+
+## Practice
+
+- **Compared with** — [[faster-rcnn]]
+  > YOLO trades localization accuracy and small-object recall for ~3× throughput; same era, different design point.
+
+## Cross-paradigm
+
+- **Learned alternative of** — [[felzenszwalb-deformable-parts]]
+  > Replaces sliding-window deformable templates with single-pass CNN regression; reframes detection as regression rather than classification of proposals.
+
+## Sources
+
+- Primary: [[redmon2016-yolo]]
+- Reference: [[dalal2005-hog]]
+- Reference: [[felzenszwalb2010-detection]]
+- Reference: [[ren2015-faster]]
+- Reference: [[simonyan2014-vgg]]
+- Reference: [[szegedy2015-inception]]

--- a/docs/atlas-vault/papers/abbas2019-bev.md
+++ b/docs/atlas-vault/papers/abbas2019-bev.md
@@ -1,0 +1,17 @@
+---
+title: "A Geometric Approach to Obtain a Bird's Eye View From an Image"
+type: paper
+paper-id: abbas2019-bev
+year: 2019
+venue: "ICCVW 2019"
+authors: ["S. A. Abbas", "A. Zisserman"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `abbas2019-bev`).
+
+S. A. Abbas, A. Zisserman · 2019 · ICCVW 2019
+
+## Cites
+
+- [[he2016-resnet]]
+- [[he2017-maskrcnn]]

--- a/docs/atlas-vault/papers/barath2019-magsac.md
+++ b/docs/atlas-vault/papers/barath2019-magsac.md
@@ -1,0 +1,17 @@
+---
+title: "MAGSAC: marginalizing sample consensus"
+type: paper
+paper-id: barath2019-magsac
+year: 2019
+venue: "CVPR"
+authors: ["D. Barath", "J. Matas", "J. Noskova"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `barath2019-magsac`).
+
+D. Barath, J. Matas, J. Noskova · 2019 · CVPR
+
+## Cites
+
+- [[fischler1981-ransac]]
+- [[raguram2013-usac]]

--- a/docs/atlas-vault/papers/bay2006-surf.md
+++ b/docs/atlas-vault/papers/bay2006-surf.md
@@ -1,0 +1,17 @@
+---
+title: "SURF: Speeded Up Robust Features"
+type: paper
+paper-id: bay2006-surf
+year: 2006
+venue: "Lecture notes in computer science"
+authors: ["H. Bay", "T. Tuytelaars", "L. V. Gool"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `bay2006-surf`).
+
+H. Bay, T. Tuytelaars, L. V. Gool · 2006 · Lecture notes in computer science
+
+## Cites
+
+- [[harris1988-corner]]
+- [[lowe2004-sift]]

--- a/docs/atlas-vault/papers/black1996-robust.md
+++ b/docs/atlas-vault/papers/black1996-robust.md
@@ -1,0 +1,17 @@
+---
+title: "The Robust Estimation of Multiple Motions: Parametric and Piecewise-Smooth Flow Fields"
+type: paper
+paper-id: black1996-robust
+year: 1996
+venue: "Computer Vision and Image Understanding"
+authors: ["M. J. Black", "P. Anandan"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `black1996-robust`).
+
+M. J. Black, P. Anandan · 1996 · Computer Vision and Image Understanding
+
+## Cites
+
+- [[horn1981-horn-schunck]]
+- [[lucas1981-lucas-kanade]]

--- a/docs/atlas-vault/papers/boykov2001-graph-cut-segmentation.md
+++ b/docs/atlas-vault/papers/boykov2001-graph-cut-segmentation.md
@@ -1,0 +1,12 @@
+---
+title: "Interactive Graph Cuts for Optimal Boundary & Region Segmentation of Objects in N-D Images"
+type: paper
+paper-id: boykov2001-graph-cut-segmentation
+year: 2001
+venue: "ICCV"
+authors: ["Y. Boykov", "M.-P. Jolly"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `boykov2001-graph-cut-segmentation`).
+
+Y. Boykov, M.-P. Jolly · 2001 · ICCV

--- a/docs/atlas-vault/papers/calonder2010-brief.md
+++ b/docs/atlas-vault/papers/calonder2010-brief.md
@@ -1,0 +1,18 @@
+---
+title: "BRIEF: Binary Robust Independent Elementary Features"
+type: paper
+paper-id: calonder2010-brief
+year: 2010
+venue: "Lecture notes in computer science"
+authors: ["M. Calonder", "V. Lepetit", "C. Strecha", "P. Fua"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `calonder2010-brief`).
+
+M. Calonder, V. Lepetit, C. Strecha, P. Fua · 2010 · Lecture notes in computer science
+
+## Cites
+
+- [[bay2006-surf]]
+- [[lowe2004-sift]]
+- [[rosten2006-fast]]

--- a/docs/atlas-vault/papers/canny1986-edge.md
+++ b/docs/atlas-vault/papers/canny1986-edge.md
@@ -1,0 +1,12 @@
+---
+title: "A Computational Approach to Edge Detection"
+type: paper
+paper-id: canny1986-edge
+year: 1986
+venue: "IEEE Transactions on Pattern Analysis and Machine Intelligence"
+authors: ["J. Canny"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `canny1986-edge`).
+
+J. Canny · 1986 · IEEE Transactions on Pattern Analysis and Machine Intelligence

--- a/docs/atlas-vault/papers/carion2020-detr.md
+++ b/docs/atlas-vault/papers/carion2020-detr.md
@@ -1,0 +1,16 @@
+---
+title: "End-to-End Object Detection with Transformers"
+type: paper
+paper-id: carion2020-detr
+year: 2020
+venue: "ECCV 2020"
+authors: ["N. Carion", "F. Massa", "G. Synnaeve", "N. Usunier", "A. Kirillov", "S. Zagoruyko"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `carion2020-detr`).
+
+N. Carion, F. Massa, G. Synnaeve, N. Usunier, A. Kirillov, S. Zagoruyko · 2020 · ECCV 2020
+
+## Cites
+
+- [[he2016-resnet]]

--- a/docs/atlas-vault/papers/carion2025-sam3.md
+++ b/docs/atlas-vault/papers/carion2025-sam3.md
@@ -1,0 +1,17 @@
+---
+title: "SAM 3: Segment Anything with Concepts"
+type: paper
+paper-id: carion2025-sam3
+year: 2025
+venue: "arXiv (Cornell University)"
+authors: ["N. Carion", "L. Gustafson", "Y. Hu", "S. Debnath", "R. Hu", "D. Suris", "C. K. Ryali", "K. V. Alwala", "H. Khedr", "A. C. Huang", "J. Lei", "T. Ma", "B. Guo", "A. Kalla", "M. D. Marks", "J. Greer", "M. Wang", "P. Sun", "R. Rädle", "T. Afouras", "E. Mavroudi", "K. Xu", "T. Wu", "Y. Zhou", "L. Momeni", "R. Hazra", "S. Ding", "S. Vaze", "F. Porcher", "L. Feng", "S. Li", "A. Kamath", "H. Cheng", "P. Dollár", "N. Ravi", "K. Saenko", "P. Zhang", "C. Feichtenhofer"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `carion2025-sam3`).
+
+N. Carion, L. Gustafson, Y. Hu, S. Debnath, R. Hu, D. Suris, C. K. Ryali, K. V. Alwala, H. Khedr, A. C. Huang, J. Lei, T. Ma, B. Guo, A. Kalla, M. D. Marks, J. Greer, M. Wang, P. Sun, R. Rädle, T. Afouras, E. Mavroudi, K. Xu, T. Wu, Y. Zhou, L. Momeni, R. Hazra, S. Ding, S. Vaze, F. Porcher, L. Feng, S. Li, A. Kamath, H. Cheng, P. Dollár, N. Ravi, K. Saenko, P. Zhang, C. Feichtenhofer · 2025 · arXiv (Cornell University)
+
+## Cites
+
+- [[kirillov2023-sam]]
+- [[ravi2024-sam2]]

--- a/docs/atlas-vault/papers/chen2018-deeplab.md
+++ b/docs/atlas-vault/papers/chen2018-deeplab.md
@@ -1,0 +1,17 @@
+---
+title: "DeepLab: Semantic Image Segmentation with Deep Convolutional Nets, Atrous Convolution, and Fully Connected CRFs"
+type: paper
+paper-id: chen2018-deeplab
+year: 2018
+venue: "IEEE Transactions on Pattern Analysis and Machine Intelligence"
+authors: ["L. Chen", "G. Papandreou", "I. Kokkinos", "K. Murphy", "A. Yuille"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `chen2018-deeplab`).
+
+L. Chen, G. Papandreou, I. Kokkinos, K. Murphy, A. Yuille · 2018 · IEEE Transactions on Pattern Analysis and Machine Intelligence
+
+## Cites
+
+- [[long2015-fcn]]
+- [[ronneberger2015-unet]]

--- a/docs/atlas-vault/papers/chen2022-focalclick.md
+++ b/docs/atlas-vault/papers/chen2022-focalclick.md
@@ -1,0 +1,12 @@
+---
+title: "FocalClick: Towards Practical Interactive Image Segmentation"
+type: paper
+paper-id: chen2022-focalclick
+year: 2022
+venue: "CVPR 2022 (arXiv 2022)"
+authors: ["X. Chen", "Z. Zhao", "Y. Zhang", "M. Duan", "D. Qi", "H. Zhao"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `chen2022-focalclick`).
+
+X. Chen, Z. Zhao, Y. Zhang, M. Duan, D. Qi, H. Zhao · 2022 · CVPR 2022 (arXiv 2022)

--- a/docs/atlas-vault/papers/cheng2021-maskformer.md
+++ b/docs/atlas-vault/papers/cheng2021-maskformer.md
@@ -1,0 +1,17 @@
+---
+title: "Per-Pixel Classification is Not All You Need for Semantic Segmentation"
+type: paper
+paper-id: cheng2021-maskformer
+year: 2021
+venue: "NeurIPS 2021"
+authors: ["B. Cheng", "A. G. Schwing", "A. Kirillov"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `cheng2021-maskformer`).
+
+B. Cheng, A. G. Schwing, A. Kirillov · 2021 · NeurIPS 2021
+
+## Cites
+
+- [[carion2020-detr]]
+- [[he2016-resnet]]

--- a/docs/atlas-vault/papers/cheng2022-mask2former.md
+++ b/docs/atlas-vault/papers/cheng2022-mask2former.md
@@ -1,0 +1,18 @@
+---
+title: "Masked-attention Mask Transformer for Universal Image Segmentation"
+type: paper
+paper-id: cheng2022-mask2former
+year: 2022
+venue: "CVPR 2022 (arXiv 2021)"
+authors: ["B. Cheng", "I. Misra", "A. G. Schwing", "A. Kirillov", "R. Girdhar"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `cheng2022-mask2former`).
+
+B. Cheng, I. Misra, A. G. Schwing, A. Kirillov, R. Girdhar · 2022 · CVPR 2022 (arXiv 2021)
+
+## Cites
+
+- [[carion2020-detr]]
+- [[cheng2021-maskformer]]
+- [[he2016-resnet]]

--- a/docs/atlas-vault/papers/crow1984-summed-area.md
+++ b/docs/atlas-vault/papers/crow1984-summed-area.md
@@ -1,0 +1,12 @@
+---
+title: "Summed-area tables for texture mapping"
+type: paper
+paper-id: crow1984-summed-area
+year: 1984
+venue: "ACM SIGGRAPH Computer Graphics"
+authors: ["F. C. Crow"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `crow1984-summed-area`).
+
+F. C. Crow · 1984 · ACM SIGGRAPH Computer Graphics

--- a/docs/atlas-vault/papers/dalal2005-hog.md
+++ b/docs/atlas-vault/papers/dalal2005-hog.md
@@ -1,0 +1,16 @@
+---
+title: "Histograms of Oriented Gradients for Human Detection"
+type: paper
+paper-id: dalal2005-hog
+year: 2005
+venue: "CVPR"
+authors: ["N. Dalal", "B. Triggs"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `dalal2005-hog`).
+
+N. Dalal, B. Triggs · 2005 · CVPR
+
+## Cites
+
+- [[lowe2004-sift]]

--- a/docs/atlas-vault/papers/dosovitskiy2020-vit.md
+++ b/docs/atlas-vault/papers/dosovitskiy2020-vit.md
@@ -1,0 +1,12 @@
+---
+title: "An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale"
+type: paper
+paper-id: dosovitskiy2020-vit
+year: 2020
+venue: "ICLR 2021 (arXiv 2020)"
+authors: ["A. Dosovitskiy", "L. Beyer", "A. Kolesnikov", "D. Weissenborn", "X. Zhai", "T. Unterthiner", "M. Dehghani", "M. Minderer", "G. Heigold", "S. Gelly", "J. Uszkoreit", "N. Houlsby"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `dosovitskiy2020-vit`).
+
+A. Dosovitskiy, L. Beyer, A. Kolesnikov, D. Weissenborn, X. Zhai, T. Unterthiner, M. Dehghani, M. Minderer, G. Heigold, S. Gelly, J. Uszkoreit, N. Houlsby · 2020 · ICLR 2021 (arXiv 2020)

--- a/docs/atlas-vault/papers/felzenszwalb2004-graph-segm.md
+++ b/docs/atlas-vault/papers/felzenszwalb2004-graph-segm.md
@@ -1,0 +1,12 @@
+---
+title: "Efficient Graph-Based Image Segmentation"
+type: paper
+paper-id: felzenszwalb2004-graph-segm
+year: 2004
+venue: "International Journal of Computer Vision"
+authors: ["P. F. Felzenszwalb", "D. P. Huttenlocher"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `felzenszwalb2004-graph-segm`).
+
+P. F. Felzenszwalb, D. P. Huttenlocher · 2004 · International Journal of Computer Vision

--- a/docs/atlas-vault/papers/felzenszwalb2010-detection.md
+++ b/docs/atlas-vault/papers/felzenszwalb2010-detection.md
@@ -1,0 +1,18 @@
+---
+title: "Object Detection with Discriminatively Trained Part-Based Models"
+type: paper
+paper-id: felzenszwalb2010-detection
+year: 2010
+venue: "IEEE TPAMI"
+authors: ["P. F. Felzenszwalb", "R. B. Girshick", "D. McAllester", "D. Ramanan"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `felzenszwalb2010-detection`).
+
+P. F. Felzenszwalb, R. B. Girshick, D. McAllester, D. Ramanan · 2010 · IEEE TPAMI
+
+## Cites
+
+- [[dalal2005-hog]]
+- [[lowe2004-sift]]
+- [[viola2001-detector]]

--- a/docs/atlas-vault/papers/fischler1981-ransac.md
+++ b/docs/atlas-vault/papers/fischler1981-ransac.md
@@ -1,0 +1,12 @@
+---
+title: "Random sample consensus: a paradigm for model fitting with applications to image analysis and automated cartography"
+type: paper
+paper-id: fischler1981-ransac
+year: 1981
+venue: "Communications of the ACM"
+authors: ["M. A. Fischler", "R. C. Bolles"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `fischler1981-ransac`).
+
+M. A. Fischler, R. C. Bolles · 1981 · Communications of the ACM

--- a/docs/atlas-vault/papers/fusiello2000-compact-rectification.md
+++ b/docs/atlas-vault/papers/fusiello2000-compact-rectification.md
@@ -1,0 +1,18 @@
+---
+title: "A Compact Algorithm for Rectification of Stereo Pairs"
+type: paper
+paper-id: fusiello2000-compact-rectification
+year: 2000
+venue: "Machine Vision and Applications"
+authors: ["A. Fusiello", "E. Trucco", "A. Verri"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `fusiello2000-compact-rectification`).
+
+A. Fusiello, E. Trucco, A. Verri · 2000 · Machine Vision and Applications
+
+## Cites
+
+- [[hartley1999-projective-rectification]]
+- [[loop1999-rectifying-homographies]]
+- [[pollefeys1999-polar-rectification]]

--- a/docs/atlas-vault/papers/hartley1999-projective-rectification.md
+++ b/docs/atlas-vault/papers/hartley1999-projective-rectification.md
@@ -1,0 +1,16 @@
+---
+title: "Theory and Practice of Projective Rectification"
+type: paper
+paper-id: hartley1999-projective-rectification
+year: 1999
+venue: "International Journal of Computer Vision"
+authors: ["R. I. Hartley"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `hartley1999-projective-rectification`).
+
+R. I. Hartley · 1999 · International Journal of Computer Vision
+
+## Cites
+
+- [[longuet-higgins1981-eight-point]]

--- a/docs/atlas-vault/papers/he2016-resnet.md
+++ b/docs/atlas-vault/papers/he2016-resnet.md
@@ -1,0 +1,19 @@
+---
+title: "Deep Residual Learning for Image Recognition"
+type: paper
+paper-id: he2016-resnet
+year: 2016
+venue: "CVPR 2016"
+authors: ["K. He", "X. Zhang", "S. Ren", "J. Sun"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `he2016-resnet`).
+
+K. He, X. Zhang, S. Ren, J. Sun · 2016 · CVPR 2016
+
+## Cites
+
+- [[krizhevsky2012-alexnet]]
+- [[long2015-fcn]]
+- [[simonyan2014-vgg]]
+- [[szegedy2015-inception]]

--- a/docs/atlas-vault/papers/he2017-maskrcnn.md
+++ b/docs/atlas-vault/papers/he2017-maskrcnn.md
@@ -1,0 +1,16 @@
+---
+title: "Mask R-CNN"
+type: paper
+paper-id: he2017-maskrcnn
+year: 2017
+venue: "ICCV"
+authors: ["K. He", "G. Gkioxari", "P. Dollár", "R. Girshick"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `he2017-maskrcnn`).
+
+K. He, G. Gkioxari, P. Dollár, R. Girshick · 2017 · ICCV
+
+## Cites
+
+- [[long2015-fcn]]

--- a/docs/atlas-vault/papers/he2021-mae.md
+++ b/docs/atlas-vault/papers/he2021-mae.md
@@ -1,0 +1,17 @@
+---
+title: "Masked Autoencoders Are Scalable Vision Learners"
+type: paper
+paper-id: he2021-mae
+year: 2021
+venue: "CVPR 2022 (arXiv 2021)"
+authors: ["K. He", "X. Chen", "S. Xie", "Y. Li", "P. Dollár", "R. Girshick"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `he2021-mae`).
+
+K. He, X. Chen, S. Xie, Y. Li, P. Dollár, R. Girshick · 2021 · CVPR 2022 (arXiv 2021)
+
+## Cites
+
+- [[dosovitskiy2020-vit]]
+- [[he2016-resnet]]

--- a/docs/atlas-vault/papers/horn1981-horn-schunck.md
+++ b/docs/atlas-vault/papers/horn1981-horn-schunck.md
@@ -1,0 +1,12 @@
+---
+title: "Determining optical flow"
+type: paper
+paper-id: horn1981-horn-schunck
+year: 1981
+venue: "Artificial Intelligence"
+authors: ["B. K. P. Horn", "B. G. Schunck"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `horn1981-horn-schunck`).
+
+B. K. P. Horn, B. G. Schunck · 1981 · Artificial Intelligence

--- a/docs/atlas-vault/papers/howard2019-mobilenetv3.md
+++ b/docs/atlas-vault/papers/howard2019-mobilenetv3.md
@@ -1,0 +1,17 @@
+---
+title: "Searching for MobileNetV3"
+type: paper
+paper-id: howard2019-mobilenetv3
+year: 2019
+venue: "ICCV 2019 (arXiv 2019)"
+authors: ["A. Howard", "M. Sandler", "G. Chu", "L. Chen", "B. Chen", "M. Tan", "W. Wang", "Y. Zhu", "R. Pang", "V. Vasudevan", "Q. V. Le", "H. Adam"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `howard2019-mobilenetv3`).
+
+A. Howard, M. Sandler, G. Chu, L. Chen, B. Chen, M. Tan, W. Wang, Y. Zhu, R. Pang, V. Vasudevan, Q. V. Le, H. Adam · 2019 · ICCV 2019 (arXiv 2019)
+
+## Cites
+
+- [[chen2018-deeplab]]
+- [[long2015-fcn]]

--- a/docs/atlas-vault/papers/kirillov2023-sam.md
+++ b/docs/atlas-vault/papers/kirillov2023-sam.md
@@ -1,0 +1,20 @@
+---
+title: "Segment Anything"
+type: paper
+paper-id: kirillov2023-sam
+year: 2023
+venue: "ICCV"
+authors: ["A. Kirillov", "E. Mintun", "N. Ravi", "H. Mao", "C. Rolland", "L. Gustafson", "T. Xiao", "S. Whitehead", "A. C. Berg", "W. Lo", "P. Dollár", "R. Girshick"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `kirillov2023-sam`).
+
+A. Kirillov, E. Mintun, N. Ravi, H. Mao, C. Rolland, L. Gustafson, T. Xiao, S. Whitehead, A. C. Berg, W. Lo, P. Dollár, R. Girshick · 2023 · ICCV
+
+## Cites
+
+- [[chen2018-deeplab]]
+- [[felzenszwalb2004-graph-segm]]
+- [[he2017-maskrcnn]]
+- [[long2015-fcn]]
+- [[ronneberger2015-unet]]

--- a/docs/atlas-vault/papers/krizhevsky2012-alexnet.md
+++ b/docs/atlas-vault/papers/krizhevsky2012-alexnet.md
@@ -1,0 +1,12 @@
+---
+title: "ImageNet Classification with Deep Convolutional Neural Networks"
+type: paper
+paper-id: krizhevsky2012-alexnet
+year: 2012
+venue: "NeurIPS"
+authors: ["A. Krizhevsky", "I. Sutskever", "G. E. Hinton"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `krizhevsky2012-alexnet`).
+
+A. Krizhevsky, I. Sutskever, G. E. Hinton · 2012 · NeurIPS

--- a/docs/atlas-vault/papers/lepetit2009-epnp.md
+++ b/docs/atlas-vault/papers/lepetit2009-epnp.md
@@ -1,0 +1,16 @@
+---
+title: "EPnP: An Accurate O(n) Solution to the PnP Problem"
+type: paper
+paper-id: lepetit2009-epnp
+year: 2009
+venue: "International Journal of Computer Vision"
+authors: ["V. Lepetit", "F. Moreno-Noguer", "P. Fua"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `lepetit2009-epnp`).
+
+V. Lepetit, F. Moreno-Noguer, P. Fua · 2009 · International Journal of Computer Vision
+
+## Cites
+
+- [[fischler1981-ransac]]

--- a/docs/atlas-vault/papers/leroy2024-mast3r.md
+++ b/docs/atlas-vault/papers/leroy2024-mast3r.md
@@ -1,0 +1,12 @@
+---
+title: "Grounding Image Matching in 3D with MASt3R"
+type: paper
+paper-id: leroy2024-mast3r
+year: 2024
+venue: "ECCV 2024"
+authors: ["V. Leroy", "Y. Cabon", "J. Revaud"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `leroy2024-mast3r`).
+
+V. Leroy, Y. Cabon, J. Revaud · 2024 · ECCV 2024

--- a/docs/atlas-vault/papers/lin2017-retinanet.md
+++ b/docs/atlas-vault/papers/lin2017-retinanet.md
@@ -1,0 +1,23 @@
+---
+title: "Focal Loss for Dense Object Detection"
+type: paper
+paper-id: lin2017-retinanet
+year: 2017
+venue: "ICCV 2017"
+authors: ["T. Lin", "P. Goyal", "R. Girshick", "K. He", "P. Dollár"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `lin2017-retinanet`).
+
+T. Lin, P. Goyal, R. Girshick, K. He, P. Dollár · 2017 · ICCV 2017
+
+## Cites
+
+- [[dalal2005-hog]]
+- [[felzenszwalb2010-detection]]
+- [[he2016-resnet]]
+- [[he2017-maskrcnn]]
+- [[krizhevsky2012-alexnet]]
+- [[long2015-fcn]]
+- [[ren2015-faster]]
+- [[viola2001-detector]]

--- a/docs/atlas-vault/papers/lin2025-depth-anything-3.md
+++ b/docs/atlas-vault/papers/lin2025-depth-anything-3.md
@@ -1,0 +1,12 @@
+---
+title: "Depth Anything 3: Recovering the Visual Space from Any Views"
+type: paper
+paper-id: lin2025-depth-anything-3
+year: 2025
+venue: "arXiv (2025)"
+authors: ["H. Lin", "S. Chen", "J. Liew", "D. Y. Chen", "Z. Li", "G. Shi", "J. Feng", "B. Kang"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `lin2025-depth-anything-3`).
+
+H. Lin, S. Chen, J. Liew, D. Y. Chen, Z. Li, G. Shi, J. Feng, B. Kang · 2025 · arXiv (2025)

--- a/docs/atlas-vault/papers/lindenberger2023-lightglue.md
+++ b/docs/atlas-vault/papers/lindenberger2023-lightglue.md
@@ -1,0 +1,19 @@
+---
+title: "LightGlue: Local Feature Matching at Light Speed"
+type: paper
+paper-id: lindenberger2023-lightglue
+year: 2023
+venue: "ICCV"
+authors: ["P. Lindenberger", "P. Sarlin", "M. Pollefeys"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `lindenberger2023-lightglue`).
+
+P. Lindenberger, P. Sarlin, M. Pollefeys · 2023 · ICCV
+
+## Cites
+
+- [[detone2018-superpoint]]
+- [[lowe2004-sift]]
+- [[sarlin2020-superglue]]
+- [[sun2021-loftr]]

--- a/docs/atlas-vault/papers/long2015-fcn.md
+++ b/docs/atlas-vault/papers/long2015-fcn.md
@@ -1,0 +1,12 @@
+---
+title: "Fully Convolutional Networks for Semantic Segmentation"
+type: paper
+paper-id: long2015-fcn
+year: 2015
+venue: "CVPR"
+authors: ["J. Long", "E. Shelhamer", "T. Darrell"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `long2015-fcn`).
+
+J. Long, E. Shelhamer, T. Darrell · 2015 · CVPR

--- a/docs/atlas-vault/papers/longuet-higgins1981-eight-point.md
+++ b/docs/atlas-vault/papers/longuet-higgins1981-eight-point.md
@@ -1,0 +1,12 @@
+---
+title: "A computer algorithm for reconstructing a scene from two projections"
+type: paper
+paper-id: longuet-higgins1981-eight-point
+year: 1981
+venue: "Nature"
+authors: ["H. C. Longuet-Higgins"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `longuet-higgins1981-eight-point`).
+
+H. C. Longuet-Higgins · 1981 · Nature

--- a/docs/atlas-vault/papers/loop1999-rectifying-homographies.md
+++ b/docs/atlas-vault/papers/loop1999-rectifying-homographies.md
@@ -1,0 +1,12 @@
+---
+title: "Computing Rectifying Homographies for Stereo Vision"
+type: paper
+paper-id: loop1999-rectifying-homographies
+year: 1999
+venue: "IEEE CVPR 1999"
+authors: ["C. Loop", "Z. Zhang"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `loop1999-rectifying-homographies`).
+
+C. Loop, Z. Zhang · 1999 · IEEE CVPR 1999

--- a/docs/atlas-vault/papers/lowe2004-sift.md
+++ b/docs/atlas-vault/papers/lowe2004-sift.md
@@ -1,0 +1,16 @@
+---
+title: "Distinctive Image Features from Scale-Invariant Keypoints"
+type: paper
+paper-id: lowe2004-sift
+year: 2004
+venue: "International Journal of Computer Vision"
+authors: ["D. G. Lowe"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `lowe2004-sift`).
+
+D. G. Lowe · 2004 · International Journal of Computer Vision
+
+## Cites
+
+- [[harris1988-corner]]

--- a/docs/atlas-vault/papers/loy2003-frst.md
+++ b/docs/atlas-vault/papers/loy2003-frst.md
@@ -1,0 +1,12 @@
+---
+title: "Fast radial symmetry for detecting points of interest"
+type: paper
+paper-id: loy2003-frst
+year: 2003
+venue: "IEEE Transactions on Pattern Analysis and Machine Intelligence"
+authors: ["Gareth Loy", "Alexander Zelinsky"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `loy2003-frst`).
+
+Gareth Loy, Alexander Zelinsky · 2003 · IEEE Transactions on Pattern Analysis and Machine Intelligence

--- a/docs/atlas-vault/papers/lucas1981-lucas-kanade.md
+++ b/docs/atlas-vault/papers/lucas1981-lucas-kanade.md
@@ -1,0 +1,12 @@
+---
+title: "An Iterative Image Registration Technique with an Application to Stereo Vision"
+type: paper
+paper-id: lucas1981-lucas-kanade
+year: 1981
+venue: "IJCAI 1981"
+authors: ["B. D. Lucas", "T. Kanade"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `lucas1981-lucas-kanade`).
+
+B. D. Lucas, T. Kanade · 1981 · IJCAI 1981

--- a/docs/atlas-vault/papers/ni2012-gfrs.md
+++ b/docs/atlas-vault/papers/ni2012-gfrs.md
@@ -1,0 +1,16 @@
+---
+title: "Fast radial symmetry detection under affine transformations"
+type: paper
+paper-id: ni2012-gfrs
+year: 2012
+venue: "IEEE Conference on Computer Vision and Pattern Recognition (CVPR)"
+authors: ["Jie Ni", "Maneesh K. Singh", "Claus Bahlmann"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `ni2012-gfrs`).
+
+Jie Ni, Maneesh K. Singh, Claus Bahlmann · 2012 · IEEE Conference on Computer Vision and Pattern Recognition (CVPR)
+
+## Cites
+
+- [[loy2003-frst]]

--- a/docs/atlas-vault/papers/oquab2023-dinov2.md
+++ b/docs/atlas-vault/papers/oquab2023-dinov2.md
@@ -1,0 +1,12 @@
+---
+title: "DINOv2: Learning Robust Visual Features without Supervision"
+type: paper
+paper-id: oquab2023-dinov2
+year: 2023
+venue: "TMLR 2024 (arXiv 2023)"
+authors: ["M. Oquab", "T. Darcet", "T. Moutakanni", "H. Vo", "M. Szafraniec", "V. Khalidov", "P. Fernandez", "D. Haziza", "F. Massa", "A. El-Nouby", "M. Assran", "N. Ballas", "W. Galuba", "R. Howes", "P. Huang", "S. Li", "I. Misra", "M. Rabbat", "V. Sharma", "G. Synnaeve", "H. Xu", "H. Jegou", "J. Mairal", "P. Labatut", "A. Joulin", "P. Bojanowski"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `oquab2023-dinov2`).
+
+M. Oquab, T. Darcet, T. Moutakanni, H. Vo, M. Szafraniec, V. Khalidov, P. Fernandez, D. Haziza, F. Massa, A. El-Nouby, M. Assran, N. Ballas, W. Galuba, R. Howes, P. Huang, S. Li, I. Misra, M. Rabbat, V. Sharma, G. Synnaeve, H. Xu, H. Jegou, J. Mairal, P. Labatut, A. Joulin, P. Bojanowski · 2023 · TMLR 2024 (arXiv 2023)

--- a/docs/atlas-vault/papers/pollefeys1999-polar-rectification.md
+++ b/docs/atlas-vault/papers/pollefeys1999-polar-rectification.md
@@ -1,0 +1,16 @@
+---
+title: "A Simple and Efficient Rectification Method for General Motion"
+type: paper
+paper-id: pollefeys1999-polar-rectification
+year: 1999
+venue: "IEEE ICCV 1999"
+authors: ["M. Pollefeys", "R. Koch", "L. Van Gool"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `pollefeys1999-polar-rectification`).
+
+M. Pollefeys, R. Koch, L. Van Gool · 1999 · IEEE ICCV 1999
+
+## Cites
+
+- [[longuet-higgins1981-eight-point]]

--- a/docs/atlas-vault/papers/poudel2019-fast-scnn.md
+++ b/docs/atlas-vault/papers/poudel2019-fast-scnn.md
@@ -1,0 +1,21 @@
+---
+title: "Fast-SCNN: Fast Semantic Segmentation Network"
+type: paper
+paper-id: poudel2019-fast-scnn
+year: 2019
+venue: "BMVC 2019 (arXiv 2019)"
+authors: ["R. P. K. Poudel", "S. Liwicki", "R. Cipolla"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `poudel2019-fast-scnn`).
+
+R. P. K. Poudel, S. Liwicki, R. Cipolla · 2019 · BMVC 2019 (arXiv 2019)
+
+## Cites
+
+- [[chen2018-deeplab]]
+- [[he2016-resnet]]
+- [[long2015-fcn]]
+- [[ronneberger2015-unet]]
+- [[simonyan2014-vgg]]
+- [[yu2018-bisenet]]

--- a/docs/atlas-vault/papers/raguram2013-usac.md
+++ b/docs/atlas-vault/papers/raguram2013-usac.md
@@ -1,0 +1,16 @@
+---
+title: "USAC: A Universal Framework for Random Sample Consensus"
+type: paper
+paper-id: raguram2013-usac
+year: 2013
+venue: "IEEE Transactions on Pattern Analysis and Machine Intelligence"
+authors: ["R. Raguram", "O. Chum", "M. Pollefeys", "J. Matas", "J. Frahm"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `raguram2013-usac`).
+
+R. Raguram, O. Chum, M. Pollefeys, J. Matas, J. Frahm · 2013 · IEEE Transactions on Pattern Analysis and Machine Intelligence
+
+## Cites
+
+- [[fischler1981-ransac]]

--- a/docs/atlas-vault/papers/ranftl2019-midas.md
+++ b/docs/atlas-vault/papers/ranftl2019-midas.md
@@ -1,0 +1,12 @@
+---
+title: "Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer"
+type: paper
+paper-id: ranftl2019-midas
+year: 2019
+venue: "TPAMI 2022 (arXiv 2019)"
+authors: ["R. Ranftl", "K. Lasinger", "D. Hafner", "K. Schindler", "V. Koltun"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `ranftl2019-midas`).
+
+R. Ranftl, K. Lasinger, D. Hafner, K. Schindler, V. Koltun · 2019 · TPAMI 2022 (arXiv 2019)

--- a/docs/atlas-vault/papers/ravi2024-sam2.md
+++ b/docs/atlas-vault/papers/ravi2024-sam2.md
@@ -1,0 +1,16 @@
+---
+title: "SAM 2: Segment Anything in Images and Videos"
+type: paper
+paper-id: ravi2024-sam2
+year: 2024
+venue: "arXiv (Cornell University)"
+authors: ["N. Ravi", "V. Gabeur", "Y. Hu", "R. Hu", "C. K. Ryali", "T. Ma", "H. Khedr", "R. Rädle", "C. Rolland", "L. Gustafson", "E. Mintun", "J. Pan", "K. V. Alwala", "N. Carion", "C. Wu", "R. Girshick", "P. Dollár", "C. Feichtenhofer"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `ravi2024-sam2`).
+
+N. Ravi, V. Gabeur, Y. Hu, R. Hu, C. K. Ryali, T. Ma, H. Khedr, R. Rädle, C. Rolland, L. Gustafson, E. Mintun, J. Pan, K. V. Alwala, N. Carion, C. Wu, R. Girshick, P. Dollár, C. Feichtenhofer · 2024 · arXiv (Cornell University)
+
+## Cites
+
+- [[kirillov2023-sam]]

--- a/docs/atlas-vault/papers/redmon2016-yolo.md
+++ b/docs/atlas-vault/papers/redmon2016-yolo.md
@@ -1,0 +1,20 @@
+---
+title: "You Only Look Once: Unified, Real-Time Object Detection"
+type: paper
+paper-id: redmon2016-yolo
+year: 2016
+venue: "CVPR 2016"
+authors: ["J. Redmon", "S. Divvala", "R. Girshick", "A. Farhadi"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `redmon2016-yolo`).
+
+J. Redmon, S. Divvala, R. Girshick, A. Farhadi · 2016 · CVPR 2016
+
+## Cites
+
+- [[dalal2005-hog]]
+- [[felzenszwalb2010-detection]]
+- [[ren2015-faster]]
+- [[simonyan2014-vgg]]
+- [[szegedy2015-inception]]

--- a/docs/atlas-vault/papers/ren2015-faster.md
+++ b/docs/atlas-vault/papers/ren2015-faster.md
@@ -1,0 +1,17 @@
+---
+title: "Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks"
+type: paper
+paper-id: ren2015-faster
+year: 2015
+venue: "NeurIPS 2015"
+authors: ["S. Ren", "K. He", "R. Girshick", "J. Sun"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `ren2015-faster`).
+
+S. Ren, K. He, R. Girshick, J. Sun · 2015 · NeurIPS 2015
+
+## Cites
+
+- [[krizhevsky2012-alexnet]]
+- [[long2015-fcn]]

--- a/docs/atlas-vault/papers/robinson2025-rf-detr.md
+++ b/docs/atlas-vault/papers/robinson2025-rf-detr.md
@@ -1,0 +1,12 @@
+---
+title: "RF-DETR: Neural Architecture Search for Real-Time Detection Transformers"
+type: paper
+paper-id: robinson2025-rf-detr
+year: 2025
+venue: "arXiv (2025)"
+authors: ["I. Robinson", "P. Robicheaux", "M. Popov", "D. Ramanan", "N. Peri"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `robinson2025-rf-detr`).
+
+I. Robinson, P. Robicheaux, M. Popov, D. Ramanan, N. Peri · 2025 · arXiv (2025)

--- a/docs/atlas-vault/papers/ronneberger2015-unet.md
+++ b/docs/atlas-vault/papers/ronneberger2015-unet.md
@@ -1,0 +1,16 @@
+---
+title: "U-Net: Convolutional Networks for Biomedical Image Segmentation"
+type: paper
+paper-id: ronneberger2015-unet
+year: 2015
+venue: "MICCAI (Lecture Notes in Computer Science)"
+authors: ["O. Ronneberger", "P. Fischer", "T. Brox"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `ronneberger2015-unet`).
+
+O. Ronneberger, P. Fischer, T. Brox · 2015 · MICCAI (Lecture Notes in Computer Science)
+
+## Cites
+
+- [[long2015-fcn]]

--- a/docs/atlas-vault/papers/rother2004-grabcut.md
+++ b/docs/atlas-vault/papers/rother2004-grabcut.md
@@ -1,0 +1,16 @@
+---
+title: "GrabCut: Interactive Foreground Extraction using Iterated Graph Cuts"
+type: paper
+paper-id: rother2004-grabcut
+year: 2004
+venue: "ACM Transactions on Graphics (SIGGRAPH)"
+authors: ["C. Rother", "V. Kolmogorov", "A. Blake"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `rother2004-grabcut`).
+
+C. Rother, V. Kolmogorov, A. Blake · 2004 · ACM Transactions on Graphics (SIGGRAPH)
+
+## Cites
+
+- [[boykov2001-graph-cut-segmentation]]

--- a/docs/atlas-vault/papers/rublee2011-orb.md
+++ b/docs/atlas-vault/papers/rublee2011-orb.md
@@ -1,0 +1,21 @@
+---
+title: "ORB: An efficient alternative to SIFT or SURF"
+type: paper
+paper-id: rublee2011-orb
+year: 2011
+venue: "ICCV"
+authors: ["E. Rublee", "V. Rabaud", "K. Konolige", "G. Bradski"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `rublee2011-orb`).
+
+E. Rublee, V. Rabaud, K. Konolige, G. Bradski · 2011 · ICCV
+
+## Cites
+
+- [[bay2006-surf]]
+- [[calonder2010-brief]]
+- [[harris1988-corner]]
+- [[lepetit2009-epnp]]
+- [[lowe2004-sift]]
+- [[rosten2006-fast]]

--- a/docs/atlas-vault/papers/sandler2018-mobilenetv2.md
+++ b/docs/atlas-vault/papers/sandler2018-mobilenetv2.md
@@ -1,0 +1,19 @@
+---
+title: "MobileNetV2: Inverted Residuals and Linear Bottlenecks"
+type: paper
+paper-id: sandler2018-mobilenetv2
+year: 2018
+venue: "CVPR 2018 (arXiv 2018)"
+authors: ["M. Sandler", "A. Howard", "M. Zhu", "A. Zhmoginov", "L. Chen"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `sandler2018-mobilenetv2`).
+
+M. Sandler, A. Howard, M. Zhu, A. Zhmoginov, L. Chen · 2018 · CVPR 2018 (arXiv 2018)
+
+## Cites
+
+- [[chen2018-deeplab]]
+- [[he2016-resnet]]
+- [[ren2015-faster]]
+- [[szegedy2015-inception]]

--- a/docs/atlas-vault/papers/sarlin2020-superglue.md
+++ b/docs/atlas-vault/papers/sarlin2020-superglue.md
@@ -1,0 +1,19 @@
+---
+title: "SuperGlue: Learning Feature Matching with Graph Neural Networks"
+type: paper
+paper-id: sarlin2020-superglue
+year: 2020
+venue: "CVPR"
+authors: ["P. Sarlin", "D. DeTone", "T. Malisiewicz", "A. Rabinovich"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `sarlin2020-superglue`).
+
+P. Sarlin, D. DeTone, T. Malisiewicz, A. Rabinovich · 2020 · CVPR
+
+## Cites
+
+- [[detone2018-superpoint]]
+- [[fischler1981-ransac]]
+- [[lowe2004-sift]]
+- [[rublee2011-orb]]

--- a/docs/atlas-vault/papers/scaramuzza2006-omni.md
+++ b/docs/atlas-vault/papers/scaramuzza2006-omni.md
@@ -1,0 +1,12 @@
+---
+title: "A Toolbox for Easily Calibrating Omnidirectional Cameras"
+type: paper
+paper-id: scaramuzza2006-omni
+year: 2006
+venue: "IEEE/RSJ IROS"
+authors: ["D. Scaramuzza", "A. Martinelli", "R. Siegwart"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `scaramuzza2006-omni`).
+
+D. Scaramuzza, A. Martinelli, R. Siegwart · 2006 · IEEE/RSJ IROS

--- a/docs/atlas-vault/papers/simonyan2014-vgg.md
+++ b/docs/atlas-vault/papers/simonyan2014-vgg.md
@@ -1,0 +1,17 @@
+---
+title: "Very Deep Convolutional Networks for Large-Scale Image Recognition"
+type: paper
+paper-id: simonyan2014-vgg
+year: 2014
+venue: "ICLR 2015 / arXiv"
+authors: ["K. Simonyan", "A. Zisserman"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `simonyan2014-vgg`).
+
+K. Simonyan, A. Zisserman · 2014 · ICLR 2015 / arXiv
+
+## Cites
+
+- [[krizhevsky2012-alexnet]]
+- [[long2015-fcn]]

--- a/docs/atlas-vault/papers/sofiiuk2021-ritm.md
+++ b/docs/atlas-vault/papers/sofiiuk2021-ritm.md
@@ -1,0 +1,12 @@
+---
+title: "Reviving Iterative Training with Mask Guidance for Interactive Segmentation"
+type: paper
+paper-id: sofiiuk2021-ritm
+year: 2021
+venue: "arXiv (Cornell University)"
+authors: ["K. Sofiiuk", "I. A. Petrov", "A. Konushin"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `sofiiuk2021-ritm`).
+
+K. Sofiiuk, I. A. Petrov, A. Konushin · 2021 · arXiv (Cornell University)

--- a/docs/atlas-vault/papers/sun2019-hrnet.md
+++ b/docs/atlas-vault/papers/sun2019-hrnet.md
@@ -1,0 +1,17 @@
+---
+title: "Deep High-Resolution Representation Learning for Human Pose Estimation"
+type: paper
+paper-id: sun2019-hrnet
+year: 2019
+venue: "CVPR 2019"
+authors: ["K. Sun", "B. Xiao", "D. Liu", "J. Wang"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `sun2019-hrnet`).
+
+K. Sun, B. Xiao, D. Liu, J. Wang · 2019 · CVPR 2019
+
+## Cites
+
+- [[he2016-resnet]]
+- [[szegedy2015-inception]]

--- a/docs/atlas-vault/papers/sun2019-hrnetv2.md
+++ b/docs/atlas-vault/papers/sun2019-hrnetv2.md
@@ -1,0 +1,18 @@
+---
+title: "High-Resolution Representations for Labeling Pixels and Regions"
+type: paper
+paper-id: sun2019-hrnetv2
+year: 2019
+venue: "arXiv (Cornell University)"
+authors: ["K. Sun", "Y. Zhao", "B. Jiang", "T. Cheng", "B. Xiao", "D. Liu", "Y. Mu", "X. Wang", "W. Liu", "J. Wang"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `sun2019-hrnetv2`).
+
+K. Sun, Y. Zhao, B. Jiang, T. Cheng, B. Xiao, D. Liu, Y. Mu, X. Wang, W. Liu, J. Wang · 2019 · arXiv (Cornell University)
+
+## Cites
+
+- [[he2016-resnet]]
+- [[he2017-maskrcnn]]
+- [[sun2019-hrnet]]

--- a/docs/atlas-vault/papers/sun2021-loftr.md
+++ b/docs/atlas-vault/papers/sun2021-loftr.md
@@ -1,0 +1,19 @@
+---
+title: "LoFTR: Detector-Free Local Feature Matching with Transformers"
+type: paper
+paper-id: sun2021-loftr
+year: 2021
+venue: "CVPR"
+authors: ["J. Sun", "Z. Shen", "Y. Wang", "H. Bao", "X. Zhou"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `sun2021-loftr`).
+
+J. Sun, Z. Shen, Y. Wang, H. Bao, X. Zhou · 2021 · CVPR
+
+## Cites
+
+- [[detone2018-superpoint]]
+- [[lowe2004-sift]]
+- [[rublee2011-orb]]
+- [[sarlin2020-superglue]]

--- a/docs/atlas-vault/papers/szegedy2015-inception.md
+++ b/docs/atlas-vault/papers/szegedy2015-inception.md
@@ -1,0 +1,16 @@
+---
+title: "Going deeper with convolutions"
+type: paper
+paper-id: szegedy2015-inception
+year: 2015
+venue: "CVPR 2015"
+authors: ["C. Szegedy", "W. Liu", "Y. Jia", "P. Sermanet", "S. Reed", "D. Anguelov", "D. Erhan", "V. Vanhoucke", "A. Rabinovich"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `szegedy2015-inception`).
+
+C. Szegedy, W. Liu, Y. Jia, P. Sermanet, S. Reed, D. Anguelov, D. Erhan, V. Vanhoucke, A. Rabinovich · 2015 · CVPR 2015
+
+## Cites
+
+- [[krizhevsky2012-alexnet]]

--- a/docs/atlas-vault/papers/tan2019-mnasnet.md
+++ b/docs/atlas-vault/papers/tan2019-mnasnet.md
@@ -1,0 +1,17 @@
+---
+title: "MnasNet: Platform-Aware Neural Architecture Search for Mobile"
+type: paper
+paper-id: tan2019-mnasnet
+year: 2019
+venue: "CVPR 2019 (arXiv 2018)"
+authors: ["M. Tan", "B. Chen", "R. Pang", "V. Vasudevan", "M. Sandler", "A. Howard", "Q. V. Le"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `tan2019-mnasnet`).
+
+M. Tan, B. Chen, R. Pang, V. Vasudevan, M. Sandler, A. Howard, Q. V. Le · 2019 · CVPR 2019 (arXiv 2018)
+
+## Cites
+
+- [[he2016-resnet]]
+- [[sandler2018-mobilenetv2]]

--- a/docs/atlas-vault/papers/tomasi1991-detection-tracking.md
+++ b/docs/atlas-vault/papers/tomasi1991-detection-tracking.md
@@ -1,0 +1,12 @@
+---
+title: "Detection and Tracking of Point Features"
+type: paper
+paper-id: tomasi1991-detection-tracking
+year: 1991
+venue: "Carnegie Mellon University Technical Report CMU-CS-91-132"
+authors: ["C. Tomasi", "T. Kanade"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `tomasi1991-detection-tracking`).
+
+C. Tomasi, T. Kanade · 1991 · Carnegie Mellon University Technical Report CMU-CS-91-132

--- a/docs/atlas-vault/papers/viola2001-detector.md
+++ b/docs/atlas-vault/papers/viola2001-detector.md
@@ -1,0 +1,12 @@
+---
+title: "Rapid object detection using a boosted cascade of simple features"
+type: paper
+paper-id: viola2001-detector
+year: 2001
+venue: "CVPR"
+authors: ["P. Viola", "M. Jones"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `viola2001-detector`).
+
+P. Viola, M. Jones · 2001 · CVPR

--- a/docs/atlas-vault/papers/wang2020-hrnet-journal.md
+++ b/docs/atlas-vault/papers/wang2020-hrnet-journal.md
@@ -1,0 +1,18 @@
+---
+title: "Deep High-Resolution Representation Learning for Visual Recognition"
+type: paper
+paper-id: wang2020-hrnet-journal
+year: 2020
+venue: "TPAMI 2020 (arXiv 2019)"
+authors: ["J. Wang", "K. Sun", "T. Cheng", "B. Jiang", "C. Deng", "Y. Zhao", "D. Liu", "Y. Mu", "M. Tan", "X. Wang", "W. Liu", "B. Xiao"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `wang2020-hrnet-journal`).
+
+J. Wang, K. Sun, T. Cheng, B. Jiang, C. Deng, Y. Zhao, D. Liu, Y. Mu, M. Tan, X. Wang, W. Liu, B. Xiao · 2020 · TPAMI 2020 (arXiv 2019)
+
+## Cites
+
+- [[he2016-resnet]]
+- [[sun2019-hrnet]]
+- [[sun2019-hrnetv2]]

--- a/docs/atlas-vault/papers/wang2023-dust3r.md
+++ b/docs/atlas-vault/papers/wang2023-dust3r.md
@@ -1,0 +1,12 @@
+---
+title: "DUSt3R: Geometric 3D Vision Made Easy"
+type: paper
+paper-id: wang2023-dust3r
+year: 2023
+venue: "CVPR 2024 (arXiv 2023)"
+authors: ["S. Wang", "V. Leroy", "Y. Cabon", "B. Chidlovskii", "J. Revaud"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `wang2023-dust3r`).
+
+S. Wang, V. Leroy, Y. Cabon, B. Chidlovskii, J. Revaud · 2023 · CVPR 2024 (arXiv 2023)

--- a/docs/atlas-vault/papers/wang2025-vggt.md
+++ b/docs/atlas-vault/papers/wang2025-vggt.md
@@ -1,0 +1,12 @@
+---
+title: "VGGT: Visual Geometry Grounded Transformer"
+type: paper
+paper-id: wang2025-vggt
+year: 2025
+venue: "CVPR 2025"
+authors: ["J. Wang", "M. Chen", "N. Karaev", "A. Vedaldi", "C. Rupprecht", "D. Novotny"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `wang2025-vggt`).
+
+J. Wang, M. Chen, N. Karaev, A. Vedaldi, C. Rupprecht, D. Novotny · 2025 · CVPR 2025

--- a/docs/atlas-vault/papers/wu2021-highly.md
+++ b/docs/atlas-vault/papers/wu2021-highly.md
@@ -1,0 +1,21 @@
+---
+title: "A highly accurate and robust deep checkerboard corner detector"
+type: paper
+paper-id: wu2021-highly
+year: 2021
+venue: "Electronics Letters"
+authors: ["Hao Wu", "Yi Wan"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `wu2021-highly`).
+
+Hao Wu, Yi Wan · 2021 · Electronics Letters
+
+## Cites
+
+- [[chen2023-ccdn]]
+- [[donne2016-mate]]
+- [[geiger2012-automatic]]
+- [[harris1988-corner]]
+- [[placht2014-rochade]]
+- [[zhang2000-flexible]]

--- a/docs/atlas-vault/papers/xie2021-segformer.md
+++ b/docs/atlas-vault/papers/xie2021-segformer.md
@@ -1,0 +1,20 @@
+---
+title: "SegFormer: Simple and Efficient Design for Semantic Segmentation with Transformers"
+type: paper
+paper-id: xie2021-segformer
+year: 2021
+venue: "NeurIPS 2021 (arXiv 2021)"
+authors: ["E. Xie", "W. Wang", "Z. Yu", "A. Anandkumar", "J. M. Alvarez", "P. Luo"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `xie2021-segformer`).
+
+E. Xie, W. Wang, Z. Yu, A. Anandkumar, J. M. Alvarez, P. Luo · 2021 · NeurIPS 2021 (arXiv 2021)
+
+## Cites
+
+- [[chen2018-deeplab]]
+- [[dosovitskiy2020-vit]]
+- [[he2016-resnet]]
+- [[long2015-fcn]]
+- [[simonyan2014-vgg]]

--- a/docs/atlas-vault/papers/yang2018-sub-pixel.md
+++ b/docs/atlas-vault/papers/yang2018-sub-pixel.md
@@ -1,0 +1,20 @@
+---
+title: "Sub-Pixel Chessboard Corner Localization for Camera Calibration and Pose Estimation"
+type: paper
+paper-id: yang2018-sub-pixel
+year: 2018
+venue: "Applied Sciences"
+authors: ["T. Yang", "Q. Zhao", "W. Xian", "Q. Zhou"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `yang2018-sub-pixel`).
+
+T. Yang, Q. Zhao, W. Xian, Q. Zhou · 2018 · Applied Sciences
+
+## Cites
+
+- [[chen2005-xcorner]]
+- [[lepetit2009-epnp]]
+- [[lucchese2003-saddle]]
+- [[placht2014-rochade]]
+- [[zhang2000-flexible]]

--- a/docs/atlas-vault/papers/yang2024-depth-anything-v2.md
+++ b/docs/atlas-vault/papers/yang2024-depth-anything-v2.md
@@ -1,0 +1,12 @@
+---
+title: "Depth Anything V2"
+type: paper
+paper-id: yang2024-depth-anything-v2
+year: 2024
+venue: "NeurIPS 2024"
+authors: ["L. Yang", "B. Kang", "Z. Huang", "Z. Zhao", "X. Xu", "J. Feng", "H. Zhao"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `yang2024-depth-anything-v2`).
+
+L. Yang, B. Kang, Z. Huang, Z. Zhao, X. Xu, J. Feng, H. Zhao · 2024 · NeurIPS 2024

--- a/docs/atlas-vault/papers/yang2024-depth-anything.md
+++ b/docs/atlas-vault/papers/yang2024-depth-anything.md
@@ -1,0 +1,12 @@
+---
+title: "Depth Anything: Unleashing the Power of Large-Scale Unlabeled Data"
+type: paper
+paper-id: yang2024-depth-anything
+year: 2024
+venue: "CVPR 2024"
+authors: ["L. Yang", "B. Kang", "Z. Huang", "X. Xu", "J. Feng", "H. Zhao"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `yang2024-depth-anything`).
+
+L. Yang, B. Kang, Z. Huang, X. Xu, J. Feng, H. Zhao · 2024 · CVPR 2024

--- a/docs/atlas-vault/papers/yu2018-bisenet.md
+++ b/docs/atlas-vault/papers/yu2018-bisenet.md
@@ -1,0 +1,21 @@
+---
+title: "BiSeNet: Bilateral Segmentation Network for Real-time Semantic Segmentation"
+type: paper
+paper-id: yu2018-bisenet
+year: 2018
+venue: "ECCV 2018 (arXiv 2018)"
+authors: ["C. Yu", "J. Wang", "C. Peng", "C. Gao", "G. Yu", "S. Nong"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `yu2018-bisenet`).
+
+C. Yu, J. Wang, C. Peng, C. Gao, G. Yu, S. Nong · 2018 · ECCV 2018 (arXiv 2018)
+
+## Cites
+
+- [[chen2018-deeplab]]
+- [[he2016-resnet]]
+- [[krizhevsky2012-alexnet]]
+- [[long2015-fcn]]
+- [[ronneberger2015-unet]]
+- [[simonyan2014-vgg]]

--- a/docs/atlas-vault/papers/yu2020-bisenet.md
+++ b/docs/atlas-vault/papers/yu2020-bisenet.md
@@ -1,0 +1,25 @@
+---
+title: "BiSeNet V2: Bilateral Network with Guided Aggregation for Real-time Semantic Segmentation"
+type: paper
+paper-id: yu2020-bisenet
+year: 2020
+venue: "IJCV 2021 (arXiv 2020)"
+authors: ["C. Yu", "C. Gao", "J. Wang", "G. Yu", "C. Shen", "S. Nong"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `yu2020-bisenet`).
+
+C. Yu, C. Gao, J. Wang, G. Yu, C. Shen, S. Nong · 2020 · IJCV 2021 (arXiv 2020)
+
+## Cites
+
+- [[boykov2001-graph-cut-segmentation]]
+- [[chen2018-deeplab]]
+- [[he2016-resnet]]
+- [[krizhevsky2012-alexnet]]
+- [[long2015-fcn]]
+- [[ronneberger2015-unet]]
+- [[rother2004-grabcut]]
+- [[simonyan2014-vgg]]
+- [[wang2020-hrnet-journal]]
+- [[yu2018-bisenet]]

--- a/docs/atlas-vault/papers/zhang2022-learning-based.md
+++ b/docs/atlas-vault/papers/zhang2022-learning-based.md
@@ -1,0 +1,23 @@
+---
+title: "Learning-Based Distortion Correction and Feature Detection for High Precision and Robust Camera Calibration"
+type: paper
+paper-id: zhang2022-learning-based
+year: 2022
+venue: "IEEE Robotics and Automation Letters"
+authors: ["Y. Zhang", "X. Zhao", "D. Qian"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `zhang2022-learning-based`).
+
+Y. Zhang, X. Zhao, D. Qian · 2022 · IEEE Robotics and Automation Letters
+
+## Cites
+
+- [[chen2023-ccdn]]
+- [[donne2016-mate]]
+- [[geiger2012-automatic]]
+- [[harris1988-corner]]
+- [[lucchese2003-saddle]]
+- [[placht2014-rochade]]
+- [[tsai1987-versatile]]
+- [[zhang2000-flexible]]

--- a/docs/atlas-vault/papers/zhang2023-mobilesam.md
+++ b/docs/atlas-vault/papers/zhang2023-mobilesam.md
@@ -1,0 +1,16 @@
+---
+title: "Faster Segment Anything: Towards Lightweight SAM for Mobile Applications"
+type: paper
+paper-id: zhang2023-mobilesam
+year: 2023
+venue: "arXiv (Cornell University)"
+authors: ["C. Zhang", "D. Han", "Y. Qiao", "J. U. Kim", "S. Bae", "S. Lee", "C. S. Hong"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `zhang2023-mobilesam`).
+
+C. Zhang, D. Han, Y. Qiao, J. U. Kim, S. Bae, S. Lee, C. S. Hong · 2023 · arXiv (Cornell University)
+
+## Cites
+
+- [[kirillov2023-sam]]

--- a/docs/atlas-vault/papers/zhang2023-mobilesamv2.md
+++ b/docs/atlas-vault/papers/zhang2023-mobilesamv2.md
@@ -1,0 +1,17 @@
+---
+title: "MobileSAMv2: Faster Segment Anything to Everything"
+type: paper
+paper-id: zhang2023-mobilesamv2
+year: 2023
+venue: "arXiv (Cornell University)"
+authors: ["C. Zhang", "D. Han", "S. Zheng", "J. Choi", "T. Kim", "C. S. Hong"]
+---
+
+> Generated stub — do not edit. Source: `docs/papers/index.yaml` (id: `zhang2023-mobilesamv2`).
+
+C. Zhang, D. Han, S. Zheng, J. Choi, T. Kim, C. S. Hong · 2023 · arXiv (Cornell University)
+
+## Cites
+
+- [[kirillov2023-sam]]
+- [[zhang2023-mobilesam]]

--- a/scripts/atlas-vault-build.ts
+++ b/scripts/atlas-vault-build.ts
@@ -15,6 +15,7 @@ import { readFileSync, readdirSync, writeFileSync, existsSync, mkdirSync, rmSync
 import { join, basename } from "node:path";
 import matter from "gray-matter";
 import { parse as parseYaml } from "yaml";
+import type { RelationType, TypedRelation } from "../src/lib/content/schema.ts";
 
 const REPO_ROOT = join(import.meta.dir, "..");
 const CONTENT_DIR = join(REPO_ROOT, "content");
@@ -23,14 +24,54 @@ const VAULT_DIR = join(REPO_ROOT, "docs", "atlas-vault");
 
 type NodeType = "algorithm" | "model" | "concept" | "paper";
 
+// ── Relation type → category + label ────────────────────────────────────────
+// Mirrors src/components/atlas/RelationshipPanel.tsx (FORWARD_LABEL, ~L14, and
+// the three sidebar categories per .claude/CLAUDE.md → "Relations field"). Kept
+// as a local copy rather than an import: the component pulls in React,
+// react-router-dom, and the generated content graph, none of which belong in
+// this Node/Bun build script. Keep in sync by hand if the label text changes.
+type RelationCategory = "Lineage" | "Practice" | "Cross-paradigm";
+
+const CATEGORY_ORDER: readonly RelationCategory[] = ["Lineage", "Practice", "Cross-paradigm"];
+
+const RELATION_CATEGORY: Record<RelationType, RelationCategory> = {
+    generalized_by: "Lineage",
+    alternative_formulation_of: "Lineage",
+    parallel_foundation_with: "Lineage",
+    extended_by: "Lineage",
+    compared_with: "Practice",
+    feeds_into: "Practice",
+    learned_alternative_of: "Cross-paradigm",
+};
+
+const RELATION_LABEL: Record<RelationType, string> = {
+    generalized_by: "Generalised by",
+    alternative_formulation_of: "Alternative formulation of",
+    parallel_foundation_with: "Parallel foundation with",
+    extended_by: "Extended by",
+    compared_with: "Compared with",
+    feeds_into: "Feeds into",
+    learned_alternative_of: "Learned alternative of",
+};
+
+function sortRelations(relations: TypedRelation[]): TypedRelation[] {
+    return [...relations].sort((a, b) => {
+        const catDiff =
+            CATEGORY_ORDER.indexOf(RELATION_CATEGORY[a.type]) -
+            CATEGORY_ORDER.indexOf(RELATION_CATEGORY[b.type]);
+        if (catDiff !== 0) return catDiff;
+        if (a.type !== b.type) return a.type.localeCompare(b.type);
+        return a.target.localeCompare(b.target);
+    });
+}
+
 interface PageNode {
     slug: string;
     type: "algorithm" | "model" | "concept";
     title: string;
     summary: string;
     prerequisites: string[];
-    related: string[];          // includes normalized relatedAlgorithms
-    comparedWith: string[];
+    relations: TypedRelation[];   // authored forward edges only; see readPages()
     failureModes: string[];
     sourcesPrimary?: string;
     sourcesReferences: string[];
@@ -58,9 +99,7 @@ interface PageFrontmatter {
     title?: string;
     summary?: string;
     prerequisites?: string[];
-    related?: string[];
-    relatedAlgorithms?: string[];
-    comparedWith?: string[];
+    relations?: TypedRelation[];
     failureModes?: string[];
     sources?: {
         primary?: string;
@@ -80,18 +119,13 @@ function readPages(dir: string, type: PageNode["type"]): PageNode[] {
         const { data } = matter(raw);
         const fm = data as PageFrontmatter;
         const slug = basename(file, ".md");
-        const related = uniqSorted([
-            ...(fm.related ?? []),
-            ...(fm.relatedAlgorithms ?? []),
-        ]);
         return {
             slug,
             type,
             title: fm.title ?? slug,
             summary: fm.summary ?? "",
             prerequisites: uniqSorted(fm.prerequisites ?? []),
-            related,
-            comparedWith: uniqSorted(fm.comparedWith ?? []),
+            relations: sortRelations(fm.relations ?? []),
             failureModes: uniqSorted(fm.failureModes ?? []),
             sourcesPrimary: fm.sources?.primary,
             sourcesReferences: uniqSorted(fm.sources?.references ?? []),
@@ -150,17 +184,31 @@ function renderPageStub(node: PageNode): string {
         for (const s of node.prerequisites) lines.push(wikilinkLine(s));
         lines.push("");
     }
-    if (node.related.length > 0) {
-        lines.push("## Related");
-        lines.push("");
-        for (const s of node.related) lines.push(wikilinkLine(s));
-        lines.push("");
-    }
-    if (node.comparedWith.length > 0) {
-        lines.push("## Compared with");
-        lines.push("");
-        for (const s of node.comparedWith) lines.push(wikilinkLine(s));
-        lines.push("");
+    if (node.relations.length > 0) {
+        const byCategory = new Map<RelationCategory, TypedRelation[]>();
+        for (const rel of node.relations) {
+            const cat = RELATION_CATEGORY[rel.type];
+            const list = byCategory.get(cat) ?? [];
+            list.push(rel);
+            byCategory.set(cat, list);
+        }
+        for (const cat of CATEGORY_ORDER) {
+            const rels = byCategory.get(cat);
+            if (!rels || rels.length === 0) continue;
+            lines.push(`## ${cat}`);
+            lines.push("");
+            for (const rel of rels) {
+                let line = `- **${RELATION_LABEL[rel.type]}** — [[${rel.target}]]`;
+                if (rel.confidence !== "high") {
+                    line += ` _(confidence: ${rel.confidence})_`;
+                }
+                lines.push(line);
+                if (rel.caution) {
+                    lines.push(`  > ${rel.caution}`);
+                }
+            }
+            lines.push("");
+        }
     }
     if (node.failureModes.length > 0) {
         lines.push("## Failure modes");
@@ -224,9 +272,10 @@ function renderVaultReadme(counts: Record<NodeType, number>): string {
         "",
         "An Obsidian-compatible projection of the atlas — every algorithm, model,",
         "concept, and paper is a stub `.md` whose body contains `[[wikilinks]]` for",
-        "every forward edge (prerequisites, related, comparedWith, failureModes,",
-        "sources, paper→paper citations). Open this folder as a vault in Obsidian",
-        "and use the graph view to look for clusters, gaps, and isolated islands.",
+        "every forward edge (prerequisites, typed relations — grouped as Lineage /",
+        "Practice / Cross-paradigm, failureModes, sources, paper→paper citations).",
+        "Open this folder as a vault in Obsidian and use the graph view to look",
+        "for clusters, gaps, and isolated islands.",
         "",
         "## Counts",
         "",

--- a/src/hooks/useAtlasGraph.ts
+++ b/src/hooks/useAtlasGraph.ts
@@ -40,9 +40,9 @@ interface UseAtlasGraphReturn {
 
 /**
  * Derive a deduplicated `{ nodes, edges }` view of the Atlas content graph.
- * Edges combine `prerequisites`, `comparedWith`, and `related` from
- * `contentGraph.forward` for every node we know about, deduped pair-wise so
- * each undirected relationship contributes a single edge.
+ * Edges combine `prerequisites` and typed `relations[]` (target only, type
+ * ignored) from `contentGraph.forward` for every node we know about, deduped
+ * pair-wise so each undirected relationship contributes a single edge.
  */
 export default function useAtlasGraph({ algorithms, models, concepts }: UseAtlasGraphArgs): UseAtlasGraphReturn {
     return useMemo(() => {


### PR DESCRIPTION
> **Stacked on #108** — base is `docs/authoring-relations-drift`. Review that first; retarget to `main` once it merges.

Two bugs, same root cause: the `relations[]` migration left consumers behind.

## 1. CI was running the wrong validator

`scripts/validate-content.ts` — slug resolution (including `relations[].target`), prerequisite cycles, source-id existence, canonical-quality gates — **was run by nothing automated.**

The `validate-content` job ran `bun run content:validate`, which maps to `scripts/content-validate.ts`: a different, much narrower script covering blog/algorithm markdown links and `relatedPosts`. Confusingly similar names, different coverage. **A broken `relations[].target` slug or a prerequisite cycle passed CI.**

Now both run, as separately-named steps so the distinction is visible in the log:

```
Install | Validate content (blog/demo links) | Validate content (Atlas graph)
```

Neither is removed — `content-validate.ts` is still the only thing checking blog/demo links. The trap is documented in the workflow and in CLAUDE.md. `bun run build` still runs neither, and CLAUDE.md now says so explicitly rather than implying a local build proves anything.

## 2. `scripts/atlas-vault-build.ts` read dead fields

It read `fm.related`, `fm.relatedAlgorithms` and `fm.comparedWith` — none of which exist on any page — so `bun run vault:build` silently emitted empty sections.

Repointed at `relations[]`, typed from `src/lib/content/schema.ts`, rendered the way the site renders it: grouped into **Lineage / Practice / Cross-paradigm** with the labels from `RelationshipPanel.tsx`, surfacing `caution` and non-`high` `confidence`.

```markdown
## Lineage

- **Parallel foundation with** — [[loop-zhang-rectification]]
  > Loop-Zhang minimises rectification distortion explicitly; Hartley minimises disparity.

## Practice

- **Compared with** — [[pollefeys-polar-rectification]]

## Cross-paradigm

- **Learned alternative of** — [[chess-corners]]
```

The label/category maps are a deliberate hand-synced copy of the component's, not an import — importing `RelationshipPanel.tsx` would drag React, react-router-dom and the generated content graph into a Bun script. Commented as such.

All 7 relation types in use were cross-checked against the maps; no `undefined` leaks into generated output.

## 3. `useAtlasGraph.ts` JSDoc

Claimed edges combine `prerequisites`, `comparedWith` and `related`. The logic already read `relations[]`. Comment only.

## Reviewing the two commits

- `abeba3d` — the four source files. **This is the commit to review.**
- `48bc814` — mechanical `vault:build` output, no hand-edits.

The vault commit is large for a reason worth flagging: the committed vault held only **79** files while `content/**` has ~240 pages, so 161 pages appear for the first time (`sift`, `orb`, most recent segmentation and depth models). **That staleness is pre-existing**, not caused by this fix — it just surfaces now. Worth deciding separately whether generated vault output belongs in git at all.

## Verification

```
bun run scripts/validate-content.ts    ✓ 122 pages, no errors
bun run build                          ✓ 131 static pages
bun run lint                           ✓ clean
npx vitest run                         ✓ 26 files, 277 tests
bun run vault:build                    ✓ 238 nodes
.github/workflows/ci.yml               ✓ valid YAML
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwFzcPMcsqkG1PCLcgg2as