### PR TITLE
ci: fail the lockfile workflow on a missing token instead of passing

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -33,8 +33,11 @@ name: Dependabot lockfile
 # skipped.
 # https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions
 #
-# Until that secret exists this workflow no-ops with an explanatory log line
-# rather than failing.
+# A missing secret FAILS this workflow. It used to no-op with a warning and exit
+# 0, which made a permanently-skipped job indistinguishable from a working one in
+# the checks UI — the token was absent for a month and every run showed green.
+# The grace period is over: the token is configured and verified, so absence is
+# now a real misconfiguration and is reported as one.
 #
 # Trade-off: once a workflow pushes to a Dependabot branch, Dependabot treats the
 # PR as modified by someone else and stops auto-rebasing it. Accepted.
@@ -48,7 +51,12 @@ permissions:
 
 concurrency:
   group: dependabot-lockfile-${{ github.ref }}
-  cancel-in-progress: true
+  # NOT cancel-in-progress: this workflow pushes to the same ref that triggers
+  # it, so the push raises a second run in this group and cancelling in progress
+  # makes the run cancel *itself*. The work still completes — but the run is
+  # reported as "cancelled", which reads as a failure. The self-triggered run is
+  # cheap: the `github.actor` guard below skips it immediately.
+  cancel-in-progress: false
 
 jobs:
   sync-lockfile:
@@ -56,40 +64,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check for push credentials
-        id: creds
+      - name: Require push credentials
         env:
           TOKEN: ${{ secrets.DEPENDABOT_LOCKFILE_TOKEN }}
         run: |
           if [ -z "$TOKEN" ]; then
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::DEPENDABOT_LOCKFILE_TOKEN is not set — skipping."
+            echo "::error::DEPENDABOT_LOCKFILE_TOKEN is not set — cannot regenerate the lockfile."
             echo "The default GITHUB_TOKEN is read-only for Dependabot-triggered events"
             echo "and its pushes do not retrigger CI, so a PAT is required."
             echo "Create a fine-grained PAT (Contents: Read and write) and store it as a"
             echo "DEPENDABOT secret — Actions secrets are NOT visible to this workflow:"
             echo "    gh secret set DEPENDABOT_LOCKFILE_TOKEN --app dependabot"
-          else
-            echo "has_token=true" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: steps.creds.outputs.has_token == 'true'
         with:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.DEPENDABOT_LOCKFILE_TOKEN }}
           persist-credentials: true
 
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
-        if: steps.creds.outputs.has_token == 'true'
 
       # Deliberately not --frozen-lockfile: regenerating the lockfile is the point.
       - name: Regenerate bun.lock
-        if: steps.creds.outputs.has_token == 'true'
         run: bun install
 
       - name: Commit and push if changed
-        if: steps.creds.outputs.has_token == 'true'
         run: |
           if git diff --quiet -- bun.lock; then
             echo "bun.lock already in sync — nothing to do."


### PR DESCRIPTION
Closes the follow-up left open by #102/#105: the Dependabot lockfile workflow's "no-op until configured" grace period is over.

## Why now

The token is **proven working**. Run [29754597258](https://github.com/VitalyVorobyev/vitavision/actions/runs/29754597258) completed every step against `dependabot/npm_and_yarn/vitavision/calib-targets-0.10.1`:

| step | result |
|---|---|
| Check for push credentials | ✅ |
| checkout | ✅ |
| setup-bun | ✅ |
| Regenerate bun.lock | ✅ |
| **Commit and push if changed** | ✅ |

It pushed `c5477dc chore(deps): regenerate bun.lock`, authored by `github-actions[bot]` — the first time this workflow has ever done real work.

## Two status-honesty bugs

**1. A missing token passed.** Every step was gated on `steps.creds.outputs.has_token == 'true'`, and the credential check logged a warning and exited **0**. A permanently-skipped job was indistinguishable from a working one in the checks UI — which is exactly how the token stayed absent for a month with three green runs (all predating the secret by ~32 minutes). Now it `exit 1`s with an `::error::`, and the per-step gating is gone.

**2. `cancel-in-progress` made the run cancel itself.** The workflow pushes to the ref that triggers it, so its own push raises a second run in the same concurrency group, which cancels the first. That's why run 29754597258 is labelled **cancelled** despite the table above — the work finished, then the run was killed at the very end. A cancelled badge reads as a failure and would have sent the next person looking for a break that isn't there.

Set to `cancel-in-progress: false`. The self-triggered run is cheap to let through: the existing `github.actor == 'dependabot[bot]'` guard skips it immediately (see run [29758509589](https://github.com/VitalyVorobyev/vitavision/actions/runs/29758509589), conclusion `skipped`).

## Verification

The YAML parses and has no leftover gating:

```
job if: github.actor == 'dependabot[bot]'
cancel-in-progress: false
  step: Require push credentials    | if: (none)
  step: actions/checkout            | if: (none)
  step: oven-sh/setup-bun           | if: (none)
  step: Regenerate bun.lock         | if: (none)
  step: Commit and push if changed  | if: (none)
leftover has_token: false
```

This workflow only triggers on `dependabot/**` pushes, so it cannot be exercised by this PR. The real test is the next Dependabot PR, which should now show a genuine `success` rather than `cancelled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwFzcPMcsqkG1PCLcgg2as